### PR TITLE
Detect unintended creation of an enumerator

### DIFF
--- a/source/RoslynAnalyzers/Extensions.cs
+++ b/source/RoslynAnalyzers/Extensions.cs
@@ -1,0 +1,37 @@
+using System.Runtime.InteropServices.ComTypes;
+using Microsoft.CodeAnalysis;
+
+namespace Octopus.RoslynAnalysers
+{
+    public static class Extensions
+    {
+        public static bool IsNonGenericType(this INamedTypeSymbol type, string name, params string[] namespaceParts)
+            => !type.IsGenericType &&
+                type.Name == name &&
+                type.IsInNamespace(namespaceParts);
+
+        public static bool IsGenericType(this INamedTypeSymbol type, string name, int numberOfGenericParameters, params string[] namespaceParts)
+            => type.IsGenericType &&
+                type.TypeArguments.Length == numberOfGenericParameters &&
+                type.Name == name &&
+                type.IsInNamespace(namespaceParts);
+
+        static bool IsInNamespace(this ITypeSymbol type, params string[] namespaceParts)
+        {
+            var ns = type.ContainingNamespace;
+            for (var x = namespaceParts.Length - 1; x >= 0; x--)
+            {
+                if (ns?.Name != namespaceParts[x])
+                    return false;
+                ns = ns.ContainingNamespace;
+            }
+
+            return ns.IsGlobalNamespace;
+        }
+
+        public static INamespaceSymbol GetTopMostNamespace(this INamespaceSymbol ns)
+            => ns.IsGlobalNamespace || ns.ContainingNamespace.IsGlobalNamespace
+                ? ns
+                : GetTopMostNamespace(ns.ContainingNamespace);
+    }
+}

--- a/source/RoslynAnalyzers/Extensions.cs
+++ b/source/RoslynAnalyzers/Extensions.cs
@@ -1,7 +1,7 @@
-using System.Runtime.InteropServices.ComTypes;
+using System;
 using Microsoft.CodeAnalysis;
 
-namespace Octopus.RoslynAnalysers
+namespace Octopus.RoslynAnalyzers
 {
     public static class Extensions
     {

--- a/source/RoslynAnalyzers/PossibleUnintentionalCreationOfEnumeratorAnalyzer.cs
+++ b/source/RoslynAnalyzers/PossibleUnintentionalCreationOfEnumeratorAnalyzer.cs
@@ -91,6 +91,7 @@ Any(). A best effort is used to catch this usage as they should mainly be under 
 
             if(targetCollectionTypeInfo.Type is INamedTypeSymbol targetCollectionType)
                 return IsIEnumerableOfT(targetCollectionType) ||
+                    IsThisTypeSpeciallyHandledByTheImplementation(targetCollectionType) ||
                     targetCollectionType.AllInterfaces.Any(IsThisTypeSpeciallyHandledByTheImplementation);
 
             return false;

--- a/source/RoslynAnalyzers/PossibleUnintentionalCreationOfEnumeratorAnalyzer.cs
+++ b/source/RoslynAnalyzers/PossibleUnintentionalCreationOfEnumeratorAnalyzer.cs
@@ -91,10 +91,12 @@ Any(). A best effort is used to catch this usage as they should mainly be under 
             var symbol = context.SemanticModel.GetSymbolInfo(memberAccessExpression).Symbol as IMethodSymbol;
             symbol = symbol?.ReducedFrom ?? symbol; // If called as an extension method gets the static invocation symbol
 
+            // Only interested in static methods with signature (IEnumerable<T>)
             if (
                 symbol == null ||
+                !symbol.ContainingType.IsStatic ||
                 symbol.Parameters.Length != 1 ||
-                !symbol.ContainingType.IsStatic
+                !IsIEnumerableOfT(symbol.Parameters[0].Type)
             )
                 return CollectionCheckRequired.None;
 
@@ -161,7 +163,7 @@ Any(). A best effort is used to catch this usage as they should mainly be under 
                 type.IsGenericType("IListProvider", 1, "System", "Linq") ||
                 type.IsNonGenericType("ICollection", "System", "Collections");
 
-        static bool IsIEnumerableOfT(INamedTypeSymbol type)
-            => type.IsGenericType("IEnumerable", 1, "System", "Collections", "Generic");
+        static bool IsIEnumerableOfT(ITypeSymbol type)
+            => type is INamedTypeSymbol named && named.IsGenericType("IEnumerable", 1, "System", "Collections", "Generic");
     }
 }

--- a/source/RoslynAnalyzers/PossibleUnintentionalCreationOfEnumeratorAnalyzer.cs
+++ b/source/RoslynAnalyzers/PossibleUnintentionalCreationOfEnumeratorAnalyzer.cs
@@ -40,10 +40,10 @@ Any(). A best effort is used to catch this usage as they should mainly be under 
         {
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
-            context.RegisterSyntaxNodeAction(CheckUnwantedMethodCalls, SyntaxKind.InvocationExpression);
+            context.RegisterSyntaxNodeAction(CheckForUnexpectedEnumeration, SyntaxKind.InvocationExpression);
         }
 
-        void CheckUnwantedMethodCalls(SyntaxNodeAnalysisContext context)
+        void CheckForUnexpectedEnumeration(SyntaxNodeAnalysisContext context)
         {
             if (
                 context.Node is InvocationExpressionSyntax invocation &&

--- a/source/RoslynAnalyzers/PossibleUnintentionalCreationOfEnumeratorAnalyzer.cs
+++ b/source/RoslynAnalyzers/PossibleUnintentionalCreationOfEnumeratorAnalyzer.cs
@@ -1,0 +1,110 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Octopus.RoslynAnalysers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class PossibleUnintentionalCreationOfEnumeratorAnalyzer : DiagnosticAnalyzer
+    {
+        const string DiagnosticId = "Octopus_PossibleUnintentionalCreationOfEnumerator";
+
+        const string Title = "Any(), Count() or None() call likely unintentionally creates an enumerator";
+
+        const string MessageFormat = "This Any(), Count() or None() call on this type likely creates an enumerator unintentionally. This can cause performance problems. Use the Count or Length properties instead.";
+        const string Category = "Octopus";
+        const string Description = @"The Any() and Count() extension methods cause the target to be enumerated unless it 
+implements IListProvider<T>, ICollection<T> or ICollection. Most collections do this, but some only implement 
+IEnumerable<T>. The creation of an enumerator is expensive relative to calling the Count or Length properties, 
+so it should be avoided when possible. We have several implementations of a None() extension method which calls 
+Any(). A best effort is used to catch this usage as they should mainly be under the Octopus namespace.";
+
+        internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Error,
+            true,
+            Description
+        );
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(CheckUnwantedMethodCalls, SyntaxKind.InvocationExpression);
+        }
+
+        void CheckUnwantedMethodCalls(SyntaxNodeAnalysisContext context)
+        {
+            if (
+                context.Node is InvocationExpressionSyntax invocation &&
+                invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
+                IsItAnExtensionMethodThatMightCreateAnEnumerator(context, memberAccess) &&
+                !IsTheTargetCollectionIgnoredForThisCheck(context, invocation)
+            )
+            {
+                var diagnostic = Diagnostic.Create(Rule, memberAccess.Name.GetLocation());
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+
+        static bool IsItAnExtensionMethodThatMightCreateAnEnumerator(SyntaxNodeAnalysisContext context, MemberAccessExpressionSyntax memberAccessExpression)
+        {
+            var symbol = context.SemanticModel.GetSymbolInfo(memberAccessExpression).Symbol as IMethodSymbol;
+            symbol = symbol?.ReducedFrom ?? symbol; // If called as an extension method gets the static invocation symbol
+
+            if (
+                symbol == null ||
+                symbol.Parameters.Length != 1 ||
+                !symbol.ContainingType.IsStatic
+            )
+                return false;
+
+            switch (symbol.Name)
+            {
+                case "Any":
+                case "Count":
+                    return symbol.ContainingType.IsNonGenericType("Enumerable", "System", "Linq");
+                case "None":
+                    return symbol.ContainingNamespace.GetTopMostNamespace().Name == "Octopus";
+                default:
+                    return false;
+            }
+        }
+
+        static bool IsTheTargetCollectionIgnoredForThisCheck(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocation)
+        {
+            var targetCollectionExpression = invocation.ArgumentList.Arguments.Count == 0
+                ? ((MemberAccessExpressionSyntax) invocation.Expression).Expression // Target of the extension method
+                : invocation.ArgumentList.Arguments[0].Expression; // Statically called argument
+
+            var targetCollectionTypeInfo = context.SemanticModel.GetTypeInfo(targetCollectionExpression);
+            if (targetCollectionTypeInfo.Type is IArrayTypeSymbol)
+                return true;
+
+            if(targetCollectionTypeInfo.Type is INamedTypeSymbol targetCollectionType)
+                return IsIEnumerableOfT(targetCollectionType) ||
+                    targetCollectionType.AllInterfaces.Any(IsThisTypeSpeciallyHandledByTheImplementation);
+
+            return false;
+        }
+
+        // The Enumerable.Any method will call Length or Count on certain interfaces bypassing the need to create an enumerator
+        // See https://github.com/dotnet/runtime/blob/master/src/libraries/System.Linq/src/System/Linq/AnyAll.cs#L18
+        // See https://github.com/dotnet/runtime/blob/master/src/libraries/System.Linq/src/System/Linq/Count.cs
+        static bool IsThisTypeSpeciallyHandledByTheImplementation(INamedTypeSymbol type)
+            => type.IsGenericType("ICollection", 1, "System", "Collections", "Generic") ||
+                type.IsGenericType("IListProvider", 1, "System", "Linq") ||
+                type.IsNonGenericType("ICollection", "System", "Collections");
+
+        static bool IsIEnumerableOfT(INamedTypeSymbol type)
+            => type.IsGenericType("IEnumerable", 1, "System", "Collections", "Generic");
+    }
+}

--- a/source/RoslynAnalyzers/PossibleUnintentionalCreationOfEnumeratorAnalyzer.cs
+++ b/source/RoslynAnalyzers/PossibleUnintentionalCreationOfEnumeratorAnalyzer.cs
@@ -15,7 +15,7 @@ namespace Octopus.RoslynAnalyzers
 
         const string Title = "Any(), Count() or None() call likely unintentionally creates an enumerator";
 
-        const string MessageFormat = "This Any(), Count() or None() call on this type likely creates an enumerator unintentionally. This can cause performance problems. Use the Count or Length properties instead.";
+        const string MessageFormat = "This Any(), Count() or None() call on this type likely creates an enumerator unintentionally. This can cause performance problems. Use our custom extension methods or the Count or Length properties instead.";
         const string Category = "Octopus";
 
         const string Description = @"The Any() and Count() extension methods cause the target to be enumerated unless it 

--- a/source/Tests/PossibleUnintentionalCreationOfEnumeratorAnalyzerFixture.cs
+++ b/source/Tests/PossibleUnintentionalCreationOfEnumeratorAnalyzerFixture.cs
@@ -85,7 +85,7 @@ namespace Tests
         }
 
         [TestCaseSource(nameof(KnownTypesThatThisCheckShouldIgnore))]
-        public async Task NoneCallIsIgnoredOnKnownTypesDetectedCorrectly(string type)
+        public async Task NoneCallIsIgnoredOnKnownTypes(string type)
         {
             var source = GetSource($"var n = {type}.None();");
             await Verify.VerifyAnalyzerAsync(source);
@@ -98,6 +98,13 @@ namespace Tests
                 @"IEnumerable<string> collection = new CustomCollection(); 
                                               var n = collection.Any();"
             );
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+
+        [Test]
+        public async Task IgnoresIfTheParameterTypeIsNotIEnumerable()
+        {
+            var source = GetSource(@"var n = ""test"".None();");
             await Verify.VerifyAnalyzerAsync(source);
         }
 
@@ -129,6 +136,9 @@ namespace Octopus.Test {
 	
 	public static class Extensions {
 		public static bool None<T>(this IEnumerable<T> collection)
+			=> false;
+
+        public static bool None(this string str)
 			=> false;
 	}
 }

--- a/source/Tests/PossibleUnintentionalCreationOfEnumeratorAnalyzerFixture.cs
+++ b/source/Tests/PossibleUnintentionalCreationOfEnumeratorAnalyzerFixture.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+using Octopus.RoslynAnalysers;
+using Verify = Microsoft.CodeAnalysis.CSharp.Testing.NUnit.AnalyzerVerifier<Octopus.RoslynAnalysers.PossibleUnintentionalCreationOfEnumeratorAnalyzer>;
+
+namespace Tests
+{
+    public class PossibleUnintentionalCreationOfEnumeratorAnalyzerFixture
+    {
+        const string CustomCollectionAndNoneExtensionSource = @"
+
+";
+
+        [Test]
+        public async Task DetectsNonExtensionInvocation()
+        {
+            var source = GetSource("var n = System.Linq.Enumerable.{|#0:Any|}(new Octopus.Test.CustomCollection());");
+            source += CustomCollectionAndNoneExtensionSource;
+            var result = new DiagnosticResult(PossibleUnintentionalCreationOfEnumeratorAnalyzer.Rule).WithLocation(0);
+
+            await Verify.VerifyAnalyzerAsync(source, result);
+        }
+
+        [TestCase("Any")]
+        [TestCase("None")]
+        [TestCase("Count")]
+        public async Task DetectsCallThatCreateAnEnumerator(string call)
+        {
+            var source = GetSource($"var n = new Octopus.Test.CustomCollection().{{|#0:{call}|}}();");
+            source += CustomCollectionAndNoneExtensionSource;
+            var result = new DiagnosticResult(PossibleUnintentionalCreationOfEnumeratorAnalyzer.Rule).WithLocation(0);
+
+            await Verify.VerifyAnalyzerAsync(source, result);
+        }
+
+        [TestCase("new List<string>().Any()")]
+        [TestCase("new Dictionary<string, string>().Any()")]
+        [TestCase("new HashSet<string>().Any()")]
+        [TestCase("new Queue<string>().Any()")] // Only implements ICollection
+        [TestCase("new string[0].Any()")]
+        public async Task IgnoresTypesWhereExtensionImplementationUsedLengthOrCountDirectly(string call)
+        {
+            var source = GetSource($"var n = {call};");
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+
+        [Test]
+        public async Task IgnoresIEnumerable()
+        {
+            var source = GetSource(@"IEnumerable<string> collection = new CustomCollection(); 
+                                              var n = collection.Any();");
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+
+        static string GetSource(string line)
+        {
+            string source = @"
+using System.Linq;
+using System.Collections;
+using System.Collections.Generic;
+using Octopus.Test;
+
+namespace TheNamespace
+{
+    class TheType
+    {
+        public void TheMethod()
+        {
+             " + line + @"
+        }
+    }        
+}
+
+namespace Octopus.Test {
+	public class CustomCollection : IEnumerable<string>
+	{
+		public IEnumerator<string> GetEnumerator() => null;
+		IEnumerator IEnumerable.GetEnumerator() => null;
+	}
+	
+	public static class Extensions {
+		public static bool None(this IEnumerable<string> collection)
+			=> false;
+	}
+}
+
+";
+            return source;
+        }
+    }
+}

--- a/source/Tests/PossibleUnintentionalCreationOfEnumeratorAnalyzerFixture.cs
+++ b/source/Tests/PossibleUnintentionalCreationOfEnumeratorAnalyzerFixture.cs
@@ -1,26 +1,26 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
 using NUnit.Framework;
-using Octopus.RoslynAnalysers;
-using Verify = Microsoft.CodeAnalysis.CSharp.Testing.NUnit.AnalyzerVerifier<Octopus.RoslynAnalysers.PossibleUnintentionalCreationOfEnumeratorAnalyzer>;
+using Octopus.RoslynAnalyzers;
+using Verify = Microsoft.CodeAnalysis.CSharp.Testing.NUnit.AnalyzerVerifier<Octopus.RoslynAnalyzers.PossibleUnintentionalCreationOfEnumeratorAnalyzer>;
 
 namespace Tests
 {
     public class PossibleUnintentionalCreationOfEnumeratorAnalyzerFixture
     {
-        const string CustomCollectionAndNoneExtensionSource = @"
-
-";
 
         [Test]
         public async Task DetectsNonExtensionInvocation()
         {
             var source = GetSource("var n = System.Linq.Enumerable.{|#0:Any|}(new Octopus.Test.CustomCollection());");
-            source += CustomCollectionAndNoneExtensionSource;
             var result = new DiagnosticResult(PossibleUnintentionalCreationOfEnumeratorAnalyzer.Rule).WithLocation(0);
 
             await Verify.VerifyAnalyzerAsync(source, result);
@@ -32,29 +32,72 @@ namespace Tests
         public async Task DetectsCallThatCreateAnEnumerator(string call)
         {
             var source = GetSource($"var n = new Octopus.Test.CustomCollection().{{|#0:{call}|}}();");
-            source += CustomCollectionAndNoneExtensionSource;
             var result = new DiagnosticResult(PossibleUnintentionalCreationOfEnumeratorAnalyzer.Rule).WithLocation(0);
 
             await Verify.VerifyAnalyzerAsync(source, result);
         }
 
-        [TestCase("new List<string>().Any()")]
-        [TestCase("((ICollection<string>) new List<string>()).Any()")]
-        [TestCase("new Dictionary<string, string>().Any()")]
-        [TestCase("new HashSet<string>().Any()")]
-        [TestCase("new Queue<string>().Any()")] // Only implements ICollection
-        [TestCase("new string[0].Any()")]
-        public async Task IgnoresTypesWhereExtensionImplementationUsedLengthOrCountDirectly(string call)
+        public static IEnumerable<string> KnownTypesThatThisCheckShouldIgnore()
         {
-            var source = GetSource($"var n = {call};");
+            yield return "new List<string>()";
+            yield return "((ICollection<string>) new List<string>())";
+            yield return "new Dictionary<string, string>()";
+            yield return "new HashSet<string>()";
+            yield return "new Queue<string>()"; // Only implements ICollection
+            yield return "new string[0]";
+            yield return "((IReadOnlyList<string>) new string[0])";
+            yield return "((IReadOnlyCollection<string>) new string[0])";
+        }
+
+        [TestCaseSource(nameof(KnownTypesThatThisCheckShouldIgnore))]
+        public async Task AnyCallIsIgnoredOnKnownTypesForNet50(string type)
+        {
+            var source = GetSource($"var n = {type}.Any();");
+            var test = new CSharpAnalyzerTest<PossibleUnintentionalCreationOfEnumeratorAnalyzer, NUnitVerifier>
+            {
+                TestCode = source,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net50
+            };
+
+            await test.RunAsync();
+        }
+
+        [TestCaseSource(nameof(KnownTypesThatThisCheckShouldIgnore))]
+        public async Task AnyCallIsDetectedOnKnownTypesForPreNet50(string type)
+        {
+            var source = GetSource($"var n = {type}.{{|#0:Any|}}();");
+            var test = new CSharpAnalyzerTest<PossibleUnintentionalCreationOfEnumeratorAnalyzer, NUnitVerifier>
+            {
+                TestCode = source,
+                ReferenceAssemblies = ReferenceAssemblies.NetCore.NetCoreApp31
+            };
+            var result = new DiagnosticResult(PossibleUnintentionalCreationOfEnumeratorAnalyzer.Rule).WithLocation(0);
+            test.ExpectedDiagnostics.Add(result);
+
+            await test.RunAsync();
+        }
+
+        [TestCaseSource(nameof(KnownTypesThatThisCheckShouldIgnore))]
+        public async Task CountCallIsIgnoredOnKnownTypes(string type)
+        {
+            var source = GetSource($"var n = {type}.Count();");
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+
+        [TestCaseSource(nameof(KnownTypesThatThisCheckShouldIgnore))]
+        public async Task NoneCallIsIgnoredOnKnownTypesDetectedCorrectly(string type)
+        {
+            var source = GetSource($"var n = {type}.None();");
             await Verify.VerifyAnalyzerAsync(source);
         }
 
         [Test]
         public async Task IgnoresIEnumerable()
         {
-            var source = GetSource(@"IEnumerable<string> collection = new CustomCollection(); 
-                                              var n = collection.Any();");
+            var source = GetSource(
+                @"IEnumerable<string> collection = new CustomCollection(); 
+                                              var n = collection.Any();"
+            );
             await Verify.VerifyAnalyzerAsync(source);
         }
 
@@ -85,7 +128,7 @@ namespace Octopus.Test {
 	}
 	
 	public static class Extensions {
-		public static bool None(this IEnumerable<string> collection)
+		public static bool None<T>(this IEnumerable<T> collection)
 			=> false;
 	}
 }

--- a/source/Tests/PossibleUnintentionalCreationOfEnumeratorAnalyzerFixture.cs
+++ b/source/Tests/PossibleUnintentionalCreationOfEnumeratorAnalyzerFixture.cs
@@ -39,6 +39,7 @@ namespace Tests
         }
 
         [TestCase("new List<string>().Any()")]
+        [TestCase("((ICollection<string>) new List<string>()).Any()")]
         [TestCase("new Dictionary<string, string>().Any()")]
         [TestCase("new HashSet<string>().Any()")]
         [TestCase("new Queue<string>().Any()")] // Only implements ICollection

--- a/source/Tests/PossibleUnintentionalCreationOfEnumeratorAnalyzerFixture.cs
+++ b/source/Tests/PossibleUnintentionalCreationOfEnumeratorAnalyzerFixture.cs
@@ -94,10 +94,14 @@ namespace Tests
         [Test]
         public async Task IgnoresIEnumerable()
         {
-            var source = GetSource(
-                @"IEnumerable<string> collection = new CustomCollection(); 
-                                              var n = collection.Any();"
-            );
+            var source = GetSource(@"var n = ((IEnumerable<string>) null).Any();");
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+
+        [Test]
+        public async Task IgnoresIGrouping()
+        {
+            var source = GetSource(@"var n = ((IGrouping<string, string>) null).Count();");
             await Verify.VerifyAnalyzerAsync(source);
         }
 


### PR DESCRIPTION
This analyzer is in response to this issue https://github.com/OctopusDeploy/Issues/issues/6679#issuecomment-776290205

A comparison of `.Count > 0` was changed to `.Any()`. However the latter creates an enumerator, which is a problem when called many times in a loop (1 million +).

This check looks for any usages of:
- `System.Linq.Enumerable.Count<T>(IEnumerable<T>)`
- `System.Linq.Enumerable.Any<T>(IEnumerable<T>)`
- `Octopus.*.None<T>(IEnumerable<T>)`

Targets of type `IEnumerable<T>` are ignored since the author likely expected an enumerator to be created.

The [implementation](https://github.com/dotnet/runtime/blob/master/src/libraries/System.Linq/src/System/Linq/Count.cs) of `Count` handles a most collections correctly via the `ICollection`, `ICollection<T>` and `IListSource` interfaces (The "Known Types"). Therefor these are ignored.

The implementation of `Any` however does not do this [until .NET 5](https://github.com/dotnet/corefx/pull/40377), so the analyzer only ignores known types on .NET 5 or later.


Running against `Octopus.Core`, it is called 20,000 or so times and 148ms is taken in this code
![image](https://user-images.githubusercontent.com/1687639/107717663-ec409000-6d1f-11eb-84f2-cda081669fdd.png)

