### PR TITLE
Added NuGet AddRange analyzer

### DIFF
--- a/source/RoslynAnalyzers/NuGetPackagingAddRangeAnalyzer.cs
+++ b/source/RoslynAnalyzers/NuGetPackagingAddRangeAnalyzer.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Octopus.RoslynAnalyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class NuGetPackagingAddRangeAnalyzer : DiagnosticAnalyzer
+    {
+        const string DiagnosticId = "Octopus_NuGetPackagingAddRange";
+
+        const string Title = "Call to AddRange in NuGet Extensions";
+
+        const string MessageFormat = "This call uses the NuGet Extension methods, it should use the one we define instead. Remove the NuGet.Packaging namespace and add Octopus.CoreUtilities.Extensions.";
+        const string Category = "Octopus";
+
+        const string Description = @"The NuGet.Packaging dll defines a AddRange extension method. We want to avoid using it as it'll lead to import clashes later.";
+
+        internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Error,
+            true,
+            Description
+        );
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(CheckForNuGetPackageAddRangeCall, SyntaxKind.InvocationExpression);
+        }
+
+        void CheckForNuGetPackageAddRangeCall(SyntaxNodeAnalysisContext context)
+        {
+            if (
+                context.Node is InvocationExpressionSyntax invocation &&
+                invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
+                memberAccess.Name.Identifier.Text == "AddRange"
+            )
+            {
+                var symbol =
+                    context.SemanticModel.GetSymbolInfo(memberAccess).Symbol as IMethodSymbol;
+                var containingType = symbol?.ReducedFrom?.ContainingType;
+
+                if (
+                    containingType != null &&
+                    containingType.IsStatic &&
+                    containingType.IsNonGenericType("CollectionExtensions", "NuGet", "Packaging")
+                )
+                {
+                    var diagnostic = Diagnostic.Create(Rule, memberAccess.Name.GetLocation());
+                    context.ReportDiagnostic(diagnostic);
+                }
+            }
+        }
+    }
+}

--- a/source/RoslynAnalyzers/NuGetPackagingAddRangeAnalyzer.cs
+++ b/source/RoslynAnalyzers/NuGetPackagingAddRangeAnalyzer.cs
@@ -14,10 +14,10 @@ namespace Octopus.RoslynAnalyzers
 
         const string Title = "Call to AddRange in NuGet Extensions";
 
-        const string MessageFormat = "This call uses the NuGet Extension methods, it should use the one we define instead. Remove the NuGet.Packaging namespace and add Octopus.CoreUtilities.Extensions.";
+        const string MessageFormat = "This call uses the NuGet Extension methods, but it should use the one we define instead. Remove the NuGet.Packaging namespace and add Octopus.CoreUtilities.Extensions.";
         const string Category = "Octopus";
 
-        const string Description = @"The NuGet.Packaging dll defines a AddRange extension method. We want to avoid using it as it'll lead to import clashes later.";
+        const string Description = @"The NuGet.Packaging dll defines an AddRange extension method. We want to avoid using it as it'll lead to import clashes later.";
 
         internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
             DiagnosticId,

--- a/source/Tests/NuGetPackagingAddRangeAnalyzerFixture.cs
+++ b/source/Tests/NuGetPackagingAddRangeAnalyzerFixture.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using NUnit.Framework;
+using Octopus.RoslynAnalyzers;
+using Verify = Microsoft.CodeAnalysis.CSharp.Testing.NUnit.AnalyzerVerifier<Octopus.RoslynAnalyzers.NuGetPackagingAddRangeAnalyzer>;
+
+namespace Tests
+{
+    public class NuGetPackagingAddRangeAnalyzerFixture
+    {
+        [Test]
+        public async Task DetectsCallToNuGetPackagingAddRangeExtension()
+        {
+            string source = @"
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using NuGet.Packaging;
+
+namespace TheNamespace
+{
+    class TheType
+    {
+        public void TheMethod()
+        {
+            new Collection<string>().{|#0:AddRange|}(new string[0]);
+            new List<string>().AddRange(new string[0]); // List has an AddRange method itself
+        }
+    }        
+}
+
+namespace NuGet.Packaging 
+{
+    public static class CollectionExtensions
+    {
+        public static void AddRange<T>(this IList<T> list, string[] items)
+        {
+        }
+    }
+}
+";
+
+            var result = new DiagnosticResult(NuGetPackagingAddRangeAnalyzer.Rule).WithLocation(0);
+
+            await Verify.VerifyAnalyzerAsync(source, result);
+        }
+    }
+}
+

--- a/source/Tests/NuGetPackagingAddRangeAnalyzerFixture.cs
+++ b/source/Tests/NuGetPackagingAddRangeAnalyzerFixture.cs
@@ -1,14 +1,6 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.IO;
-using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 using NUnit.Framework;
 using Octopus.RoslynAnalyzers;
 using Verify = Microsoft.CodeAnalysis.CSharp.Testing.NUnit.AnalyzerVerifier<Octopus.RoslynAnalyzers.NuGetPackagingAddRangeAnalyzer>;

--- a/source/Tests/PossibleUnintentionalCreationOfEnumeratorAnalyzerFixture.cs
+++ b/source/Tests/PossibleUnintentionalCreationOfEnumeratorAnalyzerFixture.cs
@@ -1,9 +1,5 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;


### PR DESCRIPTION
We commonly import the wrong AddRange which can cause namespace conflicts later.