### PR TITLE
Enum case sensitive parse analyzer

### DIFF
--- a/source/RoslynAnalyzers/CaseSensitiveEnumParsingAnalyzer.cs
+++ b/source/RoslynAnalyzers/CaseSensitiveEnumParsingAnalyzer.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Octopus.RoslynAnalyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class CaseSensitiveEnumParsingAnalyzer : DiagnosticAnalyzer
+    {
+        const string DiagnosticId = "Octopus_CaseSensitiveEnumParsingAnalyzer";
+
+        const string Title = "Enum.Parse is case sensitive";
+
+        const string MessageFormat = "The Enum.Parse call is case sensitive, which is likely not intended. Use an overload that explicitely defines case behaviour, or our `.ToEnum()` extension method.";
+        const string Category = "Octopus";
+
+        const string Description = @"Case sensitive Enum parsing has been the cause of several bugs. This analyzer forces the author to specify the casing behavior explicitely.";
+
+        internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Error,
+            true,
+            Description
+        );
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(CheckForCaseSensitiveEnumParsing, SyntaxKind.InvocationExpression);
+        }
+
+        void CheckForCaseSensitiveEnumParsing(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is InvocationExpressionSyntax invocation &&
+                invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
+                memberAccess.Expression is IdentifierNameSyntax identifierName &&
+                identifierName.Identifier.Text == "Enum" &&
+                (memberAccess.Name.Identifier.Text == "Parse" || memberAccess.Name.Identifier.Text == "TryParse"))
+            {
+                var symbol = context.SemanticModel.GetSymbolInfo(memberAccess).Symbol as IMethodSymbol;
+                if (symbol == null)
+                    return;
+
+                var indexToLookAt = symbol.IsGenericMethod ? 1 : 2;
+                if (symbol.Parameters.Length > indexToLookAt && symbol.Parameters[indexToLookAt].Name == "ignoreCase")
+                    return;
+
+                var diagnostic = Diagnostic.Create(Rule, memberAccess.Name.GetLocation());
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+    }
+}

--- a/source/RoslynAnalyzers/CaseSensitiveEnumParsingAnalyzer.cs
+++ b/source/RoslynAnalyzers/CaseSensitiveEnumParsingAnalyzer.cs
@@ -10,7 +10,7 @@ namespace Octopus.RoslynAnalyzers
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class CaseSensitiveEnumParsingAnalyzer : DiagnosticAnalyzer
     {
-        const string DiagnosticId = "Octopus_CaseSensitiveEnumParsingAnalyzer";
+        const string DiagnosticId = "Octopus_CaseSensitiveEnumParsing";
 
         const string Title = "Enum.Parse is case sensitive";
 

--- a/source/Tests/CaseSensitiveEnumParsingAnalyzerFixture.cs
+++ b/source/Tests/CaseSensitiveEnumParsingAnalyzerFixture.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using NUnit.Framework;
+using Octopus.RoslynAnalyzers;
+using Verify = Microsoft.CodeAnalysis.CSharp.Testing.NUnit.AnalyzerVerifier<Octopus.RoslynAnalyzers.CaseSensitiveEnumParsingAnalyzer>;
+
+namespace Tests
+{
+    public class CaseSensitiveEnumParsingAnalyzerFixture
+    {
+        [TestCase("Parse", "type, str")]
+        [TestCase("Parse<ConsoleColor>", "str")]
+        [TestCase("TryParse", "type, str, out var result")]
+        [TestCase("TryParse<ConsoleColor>", "str, out var result")]
+        public async Task DetectsEnumParseThatDoesNotSpecifyTheCasing(string method, string arguments)
+        {
+            var source = GetSource($"Enum.{{|#0:{method}|}}({arguments});");
+
+            var result = new DiagnosticResult(CaseSensitiveEnumParsingAnalyzer.Rule).WithLocation(0);
+
+            await Verify.VerifyAnalyzerAsync(source, result);
+        }
+
+        [TestCase("Parse", "type, str, true")]
+        [TestCase("Parse", "type, str, false")]
+        [TestCase("Parse<ConsoleColor>", "str, true")]
+        [TestCase("Parse<ConsoleColor>", "str, false")]
+        [TestCase("TryParse", "type, str, true, out var result")]
+        [TestCase("TryParse", "type, str, false, out var result")]
+        [TestCase("TryParse<ConsoleColor>", "str, true, out var result")]
+        [TestCase("TryParse<ConsoleColor>", "str, false, out var result")]
+        public async Task IgnoresEnumParseThatDoesSpecifiesTheCasing(string method, string arguments)
+        {
+            var source = GetSource($"Enum.{{|#0:{method}|}}({arguments});");
+
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+
+        static string GetSource(string line)
+        {
+            string source = @"
+using System;
+
+namespace TheNamespace
+{
+    class TheType
+    {
+        public void TheMethod()
+        {
+            var type = typeof(ConsoleColor);
+            var str = """";
+            " + line + @"
+        }
+    }        
+}
+";
+            return source;
+        }
+    }
+}
+


### PR DESCRIPTION
This picks up Enum.Parse calls that do not specify the case handling. Case sensitive parsing has lead to some bugs.