### PR TITLE
Allow future SDK versions to be used

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.104"
+    "version": "5.0.104",
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
Without this, the SDK is pinned, and if MS updates the SDK container this will stop building