### PR TITLE
Prevent Octopus.Core.Model from being passed to IResponse ctor parameters

### DIFF
--- a/source/RoslynAnalyzers/IResponseConstructorParameterAnalyzer.cs
+++ b/source/RoslynAnalyzers/IResponseConstructorParameterAnalyzer.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Octopus.RoslynAnalyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class IResponseConstructorParameterAnalyzer : DiagnosticAnalyzer
+    {
+        const string Category = "Octopus";
+        const string IResponseInterfaceName = "IResponse";
+        const string DomainModelNamespaceRoot = "Octopus.Core.Model";
+
+        const string DiagnosticId = Category + "_IResponseConstructorParameters";
+
+        const string Title = "Domain models are not allowed in " + IResponseInterfaceName + " constructors";
+
+        const string MessageFormat = IResponseInterfaceName + " implementation constructors should not take any types from " + DomainModelNamespaceRoot + ". Domain models should first be mapped to a resource.";
+
+        const string Description = IResponseInterfaceName + " forms part of the boundary between the HTTP and API layers of the Octopus Server. Domain models should not leave the API, so implementations of " + IResponseInterfaceName + " should not take any model types. Instead, map domain models to a corresponding resources.";
+
+        internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Error,
+            true,
+            Description
+        );
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(DetectIfIResponseConstructorPassesAModelType, SyntaxKind.ClassDeclaration);
+        }
+
+        void DetectIfIResponseConstructorPassesAModelType(SyntaxNodeAnalysisContext context)
+        {
+            foreach (var constructor in GetAllConstructorsFromClassesThatImplementIResponse(context))
+            {
+                foreach (var parameterSymbol in constructor.Parameters)
+                {
+                    ReportDiagnosticForParameterIfItIsADomainModel(parameterSymbol, context);
+                }
+            }
+        }
+
+        ImmutableArray<IMethodSymbol> GetAllConstructorsFromClassesThatImplementIResponse(SyntaxNodeAnalysisContext context)
+        {
+            if (context.SemanticModel.GetDeclaredSymbol(context.Node) is INamedTypeSymbol symbol &&
+                ImplementsIResponse(symbol))
+            {
+                return symbol.Constructors;
+            }
+
+            return ImmutableArray<IMethodSymbol>.Empty;
+        }
+
+        void ReportDiagnosticForParameterIfItIsADomainModel(IParameterSymbol? parameterSymbol, SyntaxNodeAnalysisContext context)
+        {
+            if (parameterSymbol == null || parameterSymbol.Type.ContainingNamespace == null)
+            {
+                return;
+            }
+
+            foreach (var namespaceSymbol in parameterSymbol.Type.ContainingNamespace.ConstituentNamespaces)
+            {
+                if (namespaceSymbol == null || !namespaceSymbol.ToString().StartsWith(DomainModelNamespaceRoot))
+                {
+                    continue;
+                }
+
+                var parameterLocation = GetParameterLocation(parameterSymbol);
+                if (parameterLocation != null)
+                {
+                    var diagnostic = Diagnostic.Create(Rule, parameterLocation);
+                    context.ReportDiagnostic(diagnostic);
+                }
+            }
+        }
+
+        static Location? GetParameterLocation(IParameterSymbol parameterSymbol)
+        {
+            var parameterDeclaringSyntaxReference = parameterSymbol.DeclaringSyntaxReferences.FirstOrDefault();
+            return parameterDeclaringSyntaxReference?.GetSyntax().GetLocation();
+        }
+
+        static bool ImplementsIResponse(INamedTypeSymbol convertedType)
+        {
+            var implementedInterfaces = convertedType?.AllInterfaces;
+            if (implementedInterfaces != null)
+            {
+                foreach (var implementedInterface in implementedInterfaces)
+                {
+                    if (implementedInterface != null && implementedInterface.Name.Equals("IResponse"))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/source/Tests/IResponseConstructorParameterAnalyzerFixture.cs
+++ b/source/Tests/IResponseConstructorParameterAnalyzerFixture.cs
@@ -1,0 +1,126 @@
+﻿using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+using Octopus.RoslynAnalyzers;
+using Verify = Microsoft.CodeAnalysis.CSharp.Testing.NUnit.AnalyzerVerifier<Octopus.RoslynAnalyzers.IResponseConstructorParameterAnalyzer>;
+
+namespace Tests
+{
+    public class IResponseConstructorParameterAnalyzerFixture
+    {
+        [Test]
+        public async Task DetectsClassesThatImplementIResponseAndPassModelTypeToCtor()
+        {
+            var source = GetInvalidSource();
+            var result = new[]
+            {
+                new DiagnosticResult(IResponseConstructorParameterAnalyzer.Rule).WithLocation(0),
+                new DiagnosticResult(IResponseConstructorParameterAnalyzer.Rule).WithLocation(1)
+            };
+            await Verify.VerifyAnalyzerAsync(source, result);
+        }
+
+        [Test]
+        public async Task NonRelevantCodeIsIgnore()
+        {
+            var source = GetNonRelevantSource();
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+
+        [Test]
+        public async Task IgnoresValidConstructorParameters()
+        {
+            var source = GetValidSource();
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+
+        static string GetInvalidSource()
+        {
+            return @"
+using System;
+
+namespace Octopus.Core.Model 
+{
+    class SomeModel
+    {
+        public SomeModel() { }
+    }
+}
+
+namespace TheNamespace
+{
+    using Octopus.Core.Model;
+
+    public interface IResponse { }
+
+    class TheType : IResponse
+    {
+        public TheType(string param1, {|#0:SomeModel model|}, int params3, {|#1:SomeModel modelTwo|}) 
+        {     
+        }
+    }        
+}
+";
+        }
+
+        static string GetValidSource()
+        {
+            return @"
+using System;
+
+namespace Octopus 
+{
+    class SomeType
+    {
+        public SomeType() { }
+    }
+}
+
+namespace TheNamespace
+{
+
+    public interface IResponse { }
+
+    class TheType : IResponse
+    {
+        public TheType(string param1, Octopus.SomeType someType, int param3)
+        {     
+        }
+       
+    }        
+}
+";
+        }
+
+        static string GetNonRelevantSource()
+        {
+            return @"
+using System;
+
+namespace Octopus 
+{
+    class SomeType
+    {
+        public SomeType() { }
+    }
+}
+
+namespace TheNamespace
+{
+    class TheType
+    {
+        public TheType(Octopus.SomeType SomeType) 
+        {     
+        }
+       
+    }     
+    
+    class OtherType
+    {
+    }
+   
+}
+";
+        }
+    }
+}


### PR DESCRIPTION
This analyzer checks for whether or not any `Octopus.Core.Model` types have been passed to an `IResponse` implementation. `IResponse` transmits data across the Domain boundary of the API (i.e. liaises between the Http and API layer of Server). 

To help prevent devs from accidentally returning Domain Models from the Api (Domain Models should not leave the API, they should instead be converted to resources), this analyzer checks for constructor arguments whose namespaces derive from `Octopus.Core.Model`. If there is one, an error is raised. 

## Before:
![image](https://user-images.githubusercontent.com/30226456/124223129-7447fa80-db46-11eb-9cf9-50df6558679a.png)


## After: 
![image](https://user-images.githubusercontent.com/30226456/124223053-51b5e180-db46-11eb-9c80-6a319a3ae314.png)
