### PR TITLE
Add analysers for Octopus server testing classes

### DIFF
--- a/source/RoslynAnalyzers/AnalyzerExtensionMethods.cs
+++ b/source/RoslynAnalyzers/AnalyzerExtensionMethods.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace Octopus.RoslynAnalyzers
+{
+    public static class AnalyzerExtensionMethods
+    {
+        public static bool ContainsTypesInheritingFromSpecifiedType(this ITypeSymbol sourceType, ITypeSymbol? baseType)
+        {
+            if (baseType is null)
+            {
+                return false;
+            }
+
+            return sourceType
+                .GetMembers()
+                .OfType<ITypeSymbol>()
+                .Any(m => m.IsAssignableTo(baseType));
+        }
+
+        public static bool IsAssignableToButNotTheSame(this ITypeSymbol? sourceType, ITypeSymbol? targetType)
+        {
+            return !SymbolEqualityComparer.Default.Equals(sourceType, targetType) && sourceType.IsAssignableTo(targetType);
+        }
+
+        public static bool IsAssignableTo(this ITypeSymbol? sourceType, ITypeSymbol? targetType)
+        {
+            if (targetType != null)
+            {
+                while (sourceType != null)
+                {
+                    if (SymbolEqualityComparer.Default.Equals(sourceType, targetType))
+                    {
+                        return true;
+                    }
+
+                    if (targetType.TypeKind == TypeKind.Interface)
+                    {
+                        return sourceType.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, targetType));
+                    }
+
+                    sourceType = sourceType.BaseType;
+                }
+            }
+
+            return false;
+        }
+
+        public static bool DirectlyInheritsFrom(this ITypeSymbol? sourceType, ITypeSymbol? baseType)
+        {
+            return sourceType?.BaseType != null && SymbolEqualityComparer.Default.Equals(sourceType.BaseType, baseType);
+        }
+
+        public static bool IsDirectlyInNamespace(this ITypeSymbol type)
+        {
+            return type.ContainingType is null;
+        }
+
+        public static IEnumerable<T> GetAllMembersOfType<T>(this ITypeSymbol type) where T : ISymbol
+        {
+            return type.GetMembers().OfType<T>();
+        }
+
+        public static IEnumerable<ISymbol> ExceptOfType<T>(this IEnumerable<ISymbol> types) where T : ISymbol
+        {
+            var typesList = types.ToList();
+            var membersOfType = typesList.OfType<T>().Cast<ISymbol>();
+            return typesList.Except(membersOfType, SymbolEqualityComparer.Default);
+        }
+
+        public static IEnumerable<ISymbol> ExceptPropertyAccessors(this IEnumerable<ISymbol> symbols)
+        {
+            return symbols.Where(s =>
+            {
+                if (s is IMethodSymbol m)
+                {
+                    return m.MethodKind != MethodKind.PropertyGet && m.MethodKind != MethodKind.PropertySet;
+                }
+
+                return true;
+            });
+        }
+
+        public static IEnumerable<ISymbol> ExceptImplicitlyDeclared(this IEnumerable<ISymbol> symbols)
+        {
+            return symbols.Where(s => !s.IsImplicitlyDeclared);
+        }
+    }
+}

--- a/source/RoslynAnalyzers/Descriptors.cs
+++ b/source/RoslynAnalyzers/Descriptors.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace Octopus.RoslynAnalyzers
+{
+    public static class Descriptors
+    {
+        static DiagnosticDescriptor GetTestAnalyzerDescriptor(string id, string title, string? description = null)
+        {
+            return new DiagnosticDescriptor(id,
+                title,
+                title,
+                "Octopus.Testing",
+                DiagnosticSeverity.Warning,
+                false, // Testing analysers are disabled by default, these will only be enabled for test projects
+                description);
+        }
+
+        static readonly string noBaseClassesDescription = "Creating base classes for tests is a really good way to make tests neat, and 1 or 2 levels " +
+            "of inheritance is generally pretty easy to reason with. From past experience, these hierarchies quickly " +
+            "get out of control and it gets really hard to find where different things set up in the chain." +
+            Environment.NewLine +
+            "If you need to share logic and resources (that are expensive to set up) between multiple tests, xUnits " +
+            "IClassFixture and IAssemblyFixture might be your answer: https://xunit.net/docs/shared-context" +
+            Environment.NewLine +
+            "If you just need to share some logic, setup, or helpers between these tests please make use of builders " +
+            "or feel free to write a custom helper or context class." +
+            Environment.NewLine +
+            "And finally, if you want to run a bunch of the same tests with slightly different configuration, make use of " +
+            "xUnit's Theories with InlineData/ClassData/MemberData. These won't run in parallel though, so please use sparingly " +
+            "in integration test land." +
+            Environment.NewLine +
+            "Reach out to @team-core-blue if you need any help with strategies to test efficiently without base classes.";
+
+        public static DiagnosticDescriptor Oct2001NoIntegrationTestBaseClasses => GetTestAnalyzerDescriptor(
+            "OCT2001",
+            "Integration test classes should inherit directly from IntegrationTest",
+            noBaseClassesDescription
+        );
+
+        public static DiagnosticDescriptor Oct2002NoUnitTestBaseClasses => GetTestAnalyzerDescriptor(
+            "OCT2002",
+            "Unit test classes should inherit directly from UnitTest",
+            noBaseClassesDescription
+        );
+
+        public static DiagnosticDescriptor Oct2003SingleIntegrationTestInEachClass => GetTestAnalyzerDescriptor(
+            "OCT2003",
+            "Integration test classes should only contain 1 test",
+            "xUnit can only run tests in parallel if they are all in different classes (check out " +
+            "more about xUnit parallelization here: https://xunit.net/docs/running-tests-in-parallel). To make " +
+            "sure we can have the fastest running integration tests in all the land, only have a single integration " +
+            "test per class. If your test classes are getting a little messy, add some nested classes to " +
+            "keep things organised." +
+            Environment.NewLine +
+            "If you need to share setup logic between tests (and now don't have a shared constructor to do that in), " +
+            "try and make use of the builders, or put together some custom helper or test context classes. If the " +
+            "setup is expensive and you need to share context between multiple tests, IClassFixture and IAssemblyFixture" +
+            "might be your answer: https://xunit.net/docs/shared-context." +
+            Environment.NewLine +
+            "Reach out to @team-core-blue if you need any help with this."
+        );
+
+        public static DiagnosticDescriptor Oct2004IntegrationTestContainerClassMustBeStatic => GetTestAnalyzerDescriptor(
+            "OCT2004",
+            "Integration test container class should be static",
+            "Integration test container classes should be static. They're containers for organisation only " +
+            "and should never be instantiated (also Rider/ReSharper gets upset if they're not static)."
+        );
+
+        public static DiagnosticDescriptor Oct2005DoNotNestIntegrationTestContainerClasses => GetTestAnalyzerDescriptor(
+            "OCT2005",
+            "Do not nest integration test container classes",
+            "A single level of nesting should be enough for organising tests in a file. Creating separate files is a" +
+            "good way to break things up. This convention is in place to stop files getting to big, and to stop tests being " +
+            "added at multiple levels of the class hierarchy in a given file."
+        );
+
+        public static DiagnosticDescriptor Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethods => GetTestAnalyzerDescriptor(
+            "OCT2006",
+            "Integration test container classes should only contain nested types and methods",
+            "Integration test container classes should only contain integration test classes and methods, any other complex logic or state " +
+            "should be in builders, class/assembly fixtures, or some other generic helper."
+        );
+        
+        public static DiagnosticDescriptor Oct2007IntegrationTestContainersMethodsMustBePrivate => GetTestAnalyzerDescriptor(
+            "OCT2007",
+            "Methods in integration test container classes should be private",
+            "Integration test container classes should only be used to organise tests (because we must have 1 test per class for maximum parallel goodness,"
+            + " any logic that you want to share across multiple tests should be in builders, class/assembly fixtures, or some other generic helper."
+        );
+    }
+}

--- a/source/RoslynAnalyzers/Testing/Constants.cs
+++ b/source/RoslynAnalyzers/Testing/Constants.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Octopus.RoslynAnalyzers.Testing
+{
+    public static class Constants
+    {
+        public static class Types
+        {
+            internal static readonly string IntegrationTest = "Octopus.IntegrationTests.IntegrationTest";
+            internal static readonly string UnitTest = "Octopus.IntegrationTests.UnitTest";
+            internal static readonly string XunitFact = "Xunit.FactAttribute";
+            internal static readonly string XunitTheory = "Xunit.TheoryAttribute";
+        }
+    }
+}

--- a/source/RoslynAnalyzers/Testing/Integration/IntegrationTestClassAnalyzer.cs
+++ b/source/RoslynAnalyzers/Testing/Integration/IntegrationTestClassAnalyzer.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Octopus.RoslynAnalyzers.Testing.Integration
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class IntegrationTestClassAnalyzer : OctopusTestingDiagnosticAnalyzer<INamedTypeSymbol>
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+            Descriptors.Oct2001NoIntegrationTestBaseClasses,
+            Descriptors.Oct2003SingleIntegrationTestInEachClass
+        );
+
+        internal override void AnalyzeCompilation(INamedTypeSymbol classSymbol, SymbolAnalysisContext context, OctopusTestingContext octopusTestingContext)
+        {
+            if (!classSymbol.IsAssignableToButNotTheSame(octopusTestingContext.IntegrationTestType))
+            {
+                return;
+            }
+
+            if (!classSymbol.DirectlyInheritsFrom(octopusTestingContext.IntegrationTestType))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Descriptors.Oct2001NoIntegrationTestBaseClasses, classSymbol.Locations.First()));
+            }
+
+            var testMethodSymbols = classSymbol
+                .GetMembers()
+                .OfType<IMethodSymbol>()
+                .Where(m => m.GetAttributes().Any(a => a.AttributeClass.IsAssignableTo(octopusTestingContext.FactAttributeType)))
+                .ToArray();
+
+            if (testMethodSymbols.Length > 1)
+            {
+                foreach (var testMethodSymbol in testMethodSymbols)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptors.Oct2003SingleIntegrationTestInEachClass, testMethodSymbol.Locations.First()));
+                }
+            }
+        }
+    }
+}

--- a/source/RoslynAnalyzers/Testing/Integration/IntegrationTestContainerAnalyzer.cs
+++ b/source/RoslynAnalyzers/Testing/Integration/IntegrationTestContainerAnalyzer.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Octopus.RoslynAnalyzers.Testing.Integration
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class IntegrationTestContainerAnalyzer : OctopusTestingDiagnosticAnalyzer<INamedTypeSymbol>
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+            Descriptors.Oct2004IntegrationTestContainerClassMustBeStatic,
+            Descriptors.Oct2005DoNotNestIntegrationTestContainerClasses,
+            Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethods,
+            Descriptors.Oct2007IntegrationTestContainersMethodsMustBePrivate);
+
+        internal override void AnalyzeCompilation(INamedTypeSymbol classSymbol, SymbolAnalysisContext context, OctopusTestingContext octopusTestingContext)
+        {
+            // A type is considered an integration test container if it has at least
+            // 1 nested type that is assignable to integration test.
+            if (!classSymbol.ContainsTypesInheritingFromSpecifiedType(octopusTestingContext.IntegrationTestType))
+            {
+                return;
+            }
+
+            if (!classSymbol.IsStatic)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Descriptors.Oct2004IntegrationTestContainerClassMustBeStatic, classSymbol.Locations.First()));
+            }
+
+            if (!classSymbol.IsDirectlyInNamespace())
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Descriptors.Oct2005DoNotNestIntegrationTestContainerClasses, classSymbol.Locations.First()));
+            }
+
+            var memberSymbolsThatAreNotTypeOrMethodDefinitions = classSymbol
+                .GetMembers()
+                .ExceptOfType<ITypeSymbol>()
+                .ExceptOfType<IMethodSymbol>()
+                .ExceptImplicitlyDeclared();
+
+            foreach (var symbol in memberSymbolsThatAreNotTypeOrMethodDefinitions)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethods, symbol.Locations.First()));
+            }
+
+            var methodsOnClassThatAreNotPrivate = classSymbol
+                .GetAllMembersOfType<IMethodSymbol>()
+                .ExceptImplicitlyDeclared()
+                .ExceptPropertyAccessors()
+                .Where(m => m.DeclaredAccessibility != Accessibility.Private);
+
+            foreach (var symbol in methodsOnClassThatAreNotPrivate)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Descriptors.Oct2007IntegrationTestContainersMethodsMustBePrivate, symbol.Locations.First()));
+            }
+        }
+    }
+}

--- a/source/RoslynAnalyzers/Testing/OctopusTestingContext.cs
+++ b/source/RoslynAnalyzers/Testing/OctopusTestingContext.cs
@@ -1,0 +1,30 @@
+using System;
+using Microsoft.CodeAnalysis;
+
+namespace Octopus.RoslynAnalyzers.Testing
+{
+    public class OctopusTestingContext
+    {
+        readonly Lazy<INamedTypeSymbol?> lazyFactAttributeType;
+        readonly Lazy<INamedTypeSymbol?> lazyTheoryAttributeType;
+        readonly Lazy<INamedTypeSymbol?> lazyIntegrationTestType;
+        readonly Lazy<INamedTypeSymbol?> lazyUnitTestType;
+
+        internal OctopusTestingContext(Compilation compilation)
+        {
+            Compilation = compilation;
+
+            lazyFactAttributeType = new Lazy<INamedTypeSymbol?>(() => compilation.GetTypeByMetadataName(Constants.Types.XunitFact));
+            lazyTheoryAttributeType = new Lazy<INamedTypeSymbol?>(() => compilation.GetTypeByMetadataName(Constants.Types.XunitTheory));
+            lazyIntegrationTestType = new Lazy<INamedTypeSymbol?>(() => compilation.GetTypeByMetadataName(Constants.Types.IntegrationTest));
+            lazyUnitTestType = new Lazy<INamedTypeSymbol?>(() => compilation.GetTypeByMetadataName(Constants.Types.UnitTest));
+        }
+
+        public Compilation Compilation { get; set; }
+
+        public INamedTypeSymbol? FactAttributeType => lazyFactAttributeType.Value;
+        public INamedTypeSymbol? TheoryAttributeType => lazyTheoryAttributeType.Value;
+        public INamedTypeSymbol? IntegrationTestType => lazyIntegrationTestType.Value;
+        public INamedTypeSymbol? UnitTestType => lazyUnitTestType.Value;
+    }
+}

--- a/source/RoslynAnalyzers/Testing/OctopusTestingDiagnosticAnalyzer.cs
+++ b/source/RoslynAnalyzers/Testing/OctopusTestingDiagnosticAnalyzer.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Octopus.RoslynAnalyzers.Testing
+{
+    public abstract class OctopusTestingDiagnosticAnalyzer<T> : DiagnosticAnalyzer where T : ISymbol
+    {
+        static readonly Dictionary<Type, SymbolKind> SymbolKindMap = new Dictionary<Type, SymbolKind>
+        {
+            { typeof(INamedTypeSymbol), SymbolKind.NamedType }
+        };
+
+        public sealed override void Initialize(AnalysisContext analysisContext)
+        {
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.RegisterCompilationStartAction(compilationStartAnalysisContext =>
+            {
+                var octopusTestingContext = new OctopusTestingContext(compilationStartAnalysisContext.Compilation);
+                var symbolKind = SymbolKindMap[typeof(T)];
+
+                compilationStartAnalysisContext.RegisterSymbolAction(context =>
+                    {
+                        var typedSymbol = (T)context.Symbol;
+                        AnalyzeCompilation(typedSymbol, context, octopusTestingContext);
+                    },
+                    symbolKind);
+            });
+        }
+
+        internal abstract void AnalyzeCompilation(T symbol, SymbolAnalysisContext context, OctopusTestingContext octopusTestingContext);
+    }
+}

--- a/source/RoslynAnalyzers/Testing/Unit/UnitTestClassAnalyzer.cs
+++ b/source/RoslynAnalyzers/Testing/Unit/UnitTestClassAnalyzer.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Octopus.RoslynAnalyzers.Testing.Unit
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class UnitTestClassAnalyzer : OctopusTestingDiagnosticAnalyzer<INamedTypeSymbol>
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptors.Oct2002NoUnitTestBaseClasses);
+
+        internal override void AnalyzeCompilation(INamedTypeSymbol classSymbol, SymbolAnalysisContext context, OctopusTestingContext octopusTestingContext)
+        {
+            if (classSymbol.IsAssignableToButNotTheSame(octopusTestingContext.UnitTestType)
+                && !classSymbol.DirectlyInheritsFrom(octopusTestingContext.UnitTestType))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Descriptors.Oct2002NoUnitTestBaseClasses, classSymbol.Locations.First()));
+            }
+        }
+    }
+}

--- a/source/Tests/CSharpVerifier.cs
+++ b/source/Tests/CSharpVerifier.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+namespace Tests
+{
+    public class CSharpVerifier<TAnalyzer> where TAnalyzer : DiagnosticAnalyzer, new()
+    {
+        public static Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+        {
+            var test = new Test<TAnalyzer>
+            {
+                TestCode = source
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            return test.RunAsync();
+        }
+    }
+
+    public class Test<TAnalyzer> : CSharpCodeFixTest<TAnalyzer, EmptyCodeFixProvider, NUnitVerifier> where TAnalyzer : DiagnosticAnalyzer, new()
+    {
+        public Test()
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Default.AddPackages(
+                ImmutableArray.Create(
+                    new PackageIdentity("xunit.core", "2.4.1")
+                )
+            );
+
+            TestBehaviors |= TestBehaviors.SkipGeneratedCodeCheck;
+        }
+    }
+}

--- a/source/Tests/Testing/Integration/IntegrationTestClassAnalyzerFixture.cs
+++ b/source/Tests/Testing/Integration/IntegrationTestClassAnalyzerFixture.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+using Octopus.RoslynAnalyzers;
+using Octopus.RoslynAnalyzers.Testing.Integration;
+using Verify = Tests.CSharpVerifier<Octopus.RoslynAnalyzers.Testing.Integration.IntegrationTestClassAnalyzer>;
+
+namespace Tests.Testing.Integration
+{
+    public class IntegrationTestClassAnalyzerFixture
+    {
+        [TestCase]
+        public async Task IgnoresClassesThatHaveNothingToDoWithThisAnalyser()
+        {
+            var container = @"
+public class JustAClassSittingAroundDoingItsThing
+{
+}
+";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+
+        [TestCase]
+        public async Task IgnoresClassesThatDirectlyInheritFromIntegrationTestAndAreEmpty()
+        {
+            var container = @"
+public class TestClass : IntegrationTest
+{
+}
+";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+
+        [TestCase]
+        public async Task DetectsClassesThatInheritFromSomeOtherClassThatInheritsFromIntegrationTest()
+        {
+            var container = @"
+public class BaseClass : IntegrationTest
+{
+}
+
+public class {|#0:TestClass|} : BaseClass
+{
+}
+";
+            var result = new DiagnosticResult(Descriptors.Oct2001NoIntegrationTestBaseClasses).WithLocation(0);
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(), result);
+        }
+
+        [TestCase]
+        public async Task IgnoresIntegrationTestClassesWithASingleFact()
+        {
+            var container = @"
+public class TestClass : IntegrationTest
+{
+    [Xunit.Fact]
+    public void Test() {}
+}
+";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+
+        [TestCase]
+        public async Task IgnoresIntegrationTestClassesWithASingleTheory()
+        {
+            var container = @"
+public class TestClass : IntegrationTest
+{
+    [Xunit.Theory]
+    [Xunit.InlineData(""1"")]
+    public void Test(string data) {}
+}
+";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+
+        [TestCase]
+        public async Task IgnoresIntegrationTestClassesWithASingleTheoryWithMultipleLinesOfData()
+        {
+            var container = @"
+public class TestClass : IntegrationTest
+{
+    [Xunit.Theory]
+    [Xunit.InlineData(""1"")]
+    [Xunit.InlineData(""2"")]
+    [Xunit.InlineData(""3"")]
+    public void Test(string data) {}
+}
+";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+
+        [TestCase]
+        public async Task IgnoresClassesThatDoNotInheritFromIntegrationTest()
+        {
+            var container = @"
+public class TestClass
+{
+    public string CanHaveThis { get; set; }
+    string thisToo;
+
+    public void SureWhyNotLetsHaveSomeMethods() { }
+}
+";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+
+        [TestCase]
+        public async Task DetectsIntegrationTestWithMoreThanOneFact()
+        {
+            var container = @"
+public class TestClass : IntegrationTest
+{
+    [Xunit.Fact]
+    public void {|#0:TheFirstFact|}()
+    {
+    }
+
+    [Xunit.Fact]
+    public void {|#1:TheSecondFact|}()
+    {
+    }
+}
+";
+            var firstTest = new DiagnosticResult(Descriptors.Oct2003SingleIntegrationTestInEachClass).WithLocation(0);
+            var secondTest = new DiagnosticResult(Descriptors.Oct2003SingleIntegrationTestInEachClass).WithLocation(1);
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(), firstTest, secondTest);
+        }
+
+        [TestCase]
+        public async Task DetectsIntegrationTestWithMoreThanOneTheory()
+        {
+            var container = @"
+public class TestClass : IntegrationTest
+{
+    [Xunit.Theory]
+    [Xunit.InlineData(""1"")]
+    public void {|#0:TheFirstTheory|}(string data)
+    {
+    }
+
+    [Xunit.Theory]
+    [Xunit.InlineData(""1"")]
+    public void {|#1:TheSecondTheory|}(string data)
+    {
+    }
+}
+";
+            var firstTest = new DiagnosticResult(Descriptors.Oct2003SingleIntegrationTestInEachClass).WithLocation(0);
+            var secondTest = new DiagnosticResult(Descriptors.Oct2003SingleIntegrationTestInEachClass).WithLocation(1);
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(), firstTest, secondTest);
+        }
+
+        [TestCase]
+        public async Task DetectsIntegrationTestWithFactsAndTheories()
+        {
+            var container = @"
+public class TestClass : IntegrationTest
+{
+    [Xunit.Fact]
+    public void {|#0:TheFact|}()
+    {
+    }
+
+    [Xunit.Theory]
+    [Xunit.InlineData(""1"")]
+    public void {|#1:TheTheory|}(string data)
+    {
+    }
+}
+";
+            var firstTest = new DiagnosticResult(Descriptors.Oct2003SingleIntegrationTestInEachClass).WithLocation(0);
+            var secondTest = new DiagnosticResult(Descriptors.Oct2003SingleIntegrationTestInEachClass).WithLocation(1);
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(), firstTest, secondTest);
+        }
+    }
+}

--- a/source/Tests/Testing/Integration/IntegrationTestContainerAnalyzerFixture.cs
+++ b/source/Tests/Testing/Integration/IntegrationTestContainerAnalyzerFixture.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+using Octopus.RoslynAnalyzers;
+using Verify = Tests.CSharpVerifier<Octopus.RoslynAnalyzers.Testing.Integration.IntegrationTestContainerAnalyzer>;
+
+namespace Tests.Testing.Integration
+{
+    public class IntegrationTestContainerAnalyzerFixture
+    {
+        [TestCase]
+        public async Task IgnoresClassesFullOfThingsThatHaveNothingToDoWithThisAnalyser()
+        {
+            var container = @"
+public class JustAClassSittingAroundDoingItsThing
+{
+    public string Property { get; set; }
+    string field;
+
+    public bool IsThisMethodSuperCool()
+    {
+        return false; // Unfortunately it is not
+    }
+}
+";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+
+        [TestCase]
+        public async Task IgnoresIntegrationTestClassesThatHaveAllSortsOfThingsInThem()
+        {
+            var container = @"
+public class AnIntegrationTestClassLivingItsOwnLife : IntegrationTest
+{
+    public string Property { get; set; }
+    string field;
+
+    public void Test()
+    {
+    }
+}
+";
+            // This analyser only cares about the integration test container classes, this
+            // code is tip-top as far as this analyser is concerned
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+
+        [TestCase]
+        public async Task IgnoresIntegrationTestContainerClassesThatAreStaticAndOnlyContainTestClasses()
+        {
+            var container = @"
+public static class TheContainerClass
+{
+    public class TestOne : IntegrationTest
+    {
+    }
+
+    public class TestTwo : IntegrationTest
+    {
+    }
+
+    public class TestThree : IntegrationTest
+    {
+    }
+}
+";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+
+        [TestCase]
+        public async Task IgnoresNestedClassesThatDoNotContainAnyTests()
+        {
+            var container = @"
+public class ContainerOne
+{
+    public class ContainerTwo
+    {
+        public class ContainerThree
+        {
+            public class ContainerFour
+            {
+            }
+        }
+    }
+}
+";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+
+        [TestCase]
+        public async Task IgnoresNestedClassesEvenIfThereIsATestIsRightAtTheTop()
+        {
+            var container = @"
+public static class ContainerOne
+{
+    public class TestClass : IntegrationTest
+    {
+    }
+
+    public class ContainerTwo
+    {
+        public class ContainerThree
+        {
+            public class ContainerFour
+            {
+            }
+        }
+    }
+}
+";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+
+        [TestCase]
+        public async Task IgnoresEverythingWhenTheIntegrationTestBaseClassDoesNotExistInTheContext()
+        {
+            var containerInStandaloneNamespace = @"
+namespace Octopus.IntegrationTests.Something
+{
+    class TheContainerClass
+    {
+        public class TheIntegrationTestClass
+        {
+        }
+    }
+}
+";
+            await Verify.VerifyAnalyzerAsync(containerInStandaloneNamespace);
+        }
+
+        [TestCase]
+        public async Task DoesNotCrashWhenTheClassBaseTypeListIsNull()
+        {
+            var container = @"
+public abstract class VersionRuleTestBase
+{
+    public class VersionRuleTestResponse
+    {
+    }
+}
+";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+
+        [TestCase]
+        public async Task DetectsIntegrationTestContainerClassesThatAreNotStatic()
+        {
+            var container = @"
+public class {|#0:TheContainerClass|}
+{
+    public class TheIntegrationTestClass : IntegrationTest
+    {
+    }
+}
+";
+            var result = new DiagnosticResult(Descriptors.Oct2004IntegrationTestContainerClassMustBeStatic).WithLocation(0);
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(), result);
+        }
+
+        [TestCase]
+        public async Task DetectsWhenThereAreTwoLevelsOfNesting()
+        {
+            var container = @"
+public static class ContainerOne
+{
+    public static class {|#0:ContainerTwo|}
+    {
+        public class TestClass : IntegrationTest
+        {
+        }
+    }
+}
+";
+            var result = new DiagnosticResult(Descriptors.Oct2005DoNotNestIntegrationTestContainerClasses).WithLocation(0);
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(), result);
+        }
+
+        [TestCase]
+        public async Task DetectsWhenThereAreManyLevelsOfNesting()
+        {
+            var container = @"
+public static class ContainerOne
+{
+    public static class ContainerTwo
+    {
+        public static class ContainerThree
+        {
+            public static class {|#0:ContainerFour|}
+            {
+                public class TestClass : IntegrationTest
+                {
+                }
+            }
+        }
+    }
+}
+";
+            var result = new DiagnosticResult(Descriptors.Oct2005DoNotNestIntegrationTestContainerClasses).WithLocation(0);
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(), result);
+        }
+
+        [TestCase]
+        public async Task DetectsIntegrationTestContainerClassesWithMembersThatAreNotTypesOrPrivateMethods()
+        {
+            var container = @"
+public static class Container
+{
+    public static string {|#0:Property|} { get; set; }
+    static string {|#1:field|};
+
+    public static void {|#2:PublicMethod|}()
+    {
+    }
+
+    static void PrivateMethod()
+    {
+    }
+
+    public class TestOne : IntegrationTest
+    {
+    }
+}
+";
+            var propertyResult = new DiagnosticResult(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethods).WithLocation(0);
+            var fieldResult = new DiagnosticResult(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethods).WithLocation(1);
+            var methodResult = new DiagnosticResult(Descriptors.Oct2007IntegrationTestContainersMethodsMustBePrivate).WithLocation(2);
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(), propertyResult, fieldResult, methodResult);
+        }
+    }
+}

--- a/source/Tests/Testing/TestingExtensionMethods.cs
+++ b/source/Tests/Testing/TestingExtensionMethods.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace Tests.Testing
+{
+    public static class TestingExtensionMethods
+    {
+        public static string WithTestingTypes(this string classStructureToTest)
+        {
+            return $@"
+using System;
+
+namespace Octopus.IntegrationTests
+{{
+    public abstract class LoggedTest : IDisposable
+    {{
+        public void Dispose() {{ }}
+    }}
+
+    public abstract class IntegrationTest : LoggedTest {{ }}
+
+    public abstract class UnitTest : LoggedTest {{ }}
+}}
+
+namespace Octopus.IntegrationTests.Something
+{{
+{classStructureToTest}
+}}
+";
+        }
+    }
+}

--- a/source/Tests/Testing/Unit/UnitTestClassAnalyzerFixture.cs
+++ b/source/Tests/Testing/Unit/UnitTestClassAnalyzerFixture.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+using Octopus.RoslynAnalyzers;
+using Verify = Tests.CSharpVerifier<Octopus.RoslynAnalyzers.Testing.Unit.UnitTestClassAnalyzer>;
+
+namespace Tests.Testing.Unit
+{
+    public class UnitTestClassAnalyzerFixture
+    {
+        [TestCase]
+        public async Task IgnoresClassesThatHaveNothingToDoWithThisAnalyser()
+        {
+            var container = @"
+public class JustAClassSittingAroundDoingItsThing
+{
+}
+";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+
+        [TestCase]
+        public async Task IgnoresClassesThatDirectlyInheritFromUnitTest()
+        {
+            var container = @"
+public class TestClass : UnitTest
+{
+}
+";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+
+        [TestCase]
+        public async Task DetectsClassesThatInheritFromSomeOtherClassThatInheritsFromUnitTest()
+        {
+            var container = @"
+public class BaseClass : UnitTest
+{
+}
+
+public class {|#0:TestClass|} : BaseClass
+{
+}
+
+";
+            var result = new DiagnosticResult(Descriptors.Oct2002NoUnitTestBaseClasses).WithLocation(0);
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(), result);
+        }
+    }
+}

--- a/source/Tests/Tests.csproj
+++ b/source/Tests/Tests.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis" Version="3.8.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit" Version="1.0.1-beta1.21064.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.NUnit" Version="1.0.1-beta1.21064.2" />
+    <PackageReference Include="xunit.core" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The plan is for these to replace the convention tests that we currently have in place in the Octopus Server solution enforcing structure around tests. Switching these to analysers to give faster feedback on violations.

I've pulled a lot of ideas from the xUnit analyser repo for these. The analysers they have over there are super helpful.