### PR TITLE
Add analyzer for "using" declarations

### DIFF
--- a/source/RoslynAnalyzers/UsingDeclarationAnalyzer.cs
+++ b/source/RoslynAnalyzers/UsingDeclarationAnalyzer.cs
@@ -14,7 +14,7 @@ namespace Octopus.RoslynAnalyzers
 
         const string Title = "\"Using\" declarations encourage holding onto IDisposable's for longer than needed";
 
-        const string MessageFormat = "Please use braces to specify the scope of the \"Using\" statement instead";
+        const string MessageFormat = "\"Using\" declarations encourage holding onto IDisposable's for longer than needed, please use braces to specify the scope of the \"Using\" statement instead";
         const string Category = "Octopus";
 
         const string Description = @"""Using"" declarations (without braces to specify the scope) have been sources of bugs where IDisposable's are held longer than needed. 

--- a/source/RoslynAnalyzers/UsingDeclarationAnalyzer.cs
+++ b/source/RoslynAnalyzers/UsingDeclarationAnalyzer.cs
@@ -12,12 +12,15 @@ namespace Octopus.RoslynAnalyzers
     {
         const string DiagnosticId = "Octopus_UsingDeclaration";
 
-        const string Title = "USING declarations are prone to errors";
+        const string Title = "\"Using\" declarations encourage holding onto IDisposable's for longer than needed";
 
-        const string MessageFormat = "The USING declaration without braces is prone to errors";
+        const string MessageFormat = "Please use braces to specify the scope of the \"Using\" statement instead";
         const string Category = "Octopus";
 
-        const string Description = @"USING declarations have been sources of bugs where transactions are held longer than needed. This analyzer bans their usage.";
+        const string Description = @"""Using"" declarations (without braces to specify the scope) have been sources of bugs where IDisposable's are held longer than needed. 
+The problem is especially tricky if long running code is added to the function AFTER the ""using"" declaration is written.
+
+This is This analyzer bans their usage.";
 
         internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
             DiagnosticId,

--- a/source/RoslynAnalyzers/UsingDeclarationAnalyzer.cs
+++ b/source/RoslynAnalyzers/UsingDeclarationAnalyzer.cs
@@ -20,7 +20,7 @@ namespace Octopus.RoslynAnalyzers
         const string Description = @"""Using"" declarations (without braces to specify the scope) have been sources of bugs where IDisposable's are held longer than needed. 
 The problem is especially tricky if long running code is added to the function AFTER the ""using"" declaration is written.
 
-This is This analyzer bans their usage.";
+This analyzer bans their usage.";
 
         internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
             DiagnosticId,

--- a/source/RoslynAnalyzers/UsingDeclarationAnalyzer.cs
+++ b/source/RoslynAnalyzers/UsingDeclarationAnalyzer.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Octopus.RoslynAnalyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class UsingDeclarationAnalyzer : DiagnosticAnalyzer
+    {
+        const string DiagnosticId = "Octopus_UsingDeclaration";
+
+        const string Title = "USING declarations are prone to errors";
+
+        const string MessageFormat = "The USING declaration without braces is prone to errors";
+        const string Category = "Octopus";
+
+        const string Description = @"USING declarations have been sources of bugs where transactions are held longer than needed. This analyzer bans their usage.";
+
+        internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Error,
+            true,
+            Description
+        );
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(CheckForUsingDeclaration, SyntaxKind.LocalDeclarationStatement);
+        }
+
+        void CheckForUsingDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is LocalDeclarationStatementSyntax syntax && (string?)syntax.UsingKeyword.Value == "using")
+            {
+                var diagnostic = Diagnostic.Create(Rule, context.Node.GetLocation());
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
+    }
+}

--- a/source/Tests/UsingDeclarationAnalyzerFixture.cs
+++ b/source/Tests/UsingDeclarationAnalyzerFixture.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Text;
 using NUnit.Framework;
 using Octopus.RoslynAnalyzers;
 using Verify = Microsoft.CodeAnalysis.CSharp.Testing.NUnit.AnalyzerVerifier<Octopus.RoslynAnalyzers.UsingDeclarationAnalyzer>;
@@ -10,7 +9,28 @@ namespace Tests
 {
     public class UsingDeclarationAnalyzerFixture
     {
-        static string usingBlock = @"
+        [Test]
+        public async Task DetectsUsingDeclaration()
+        {
+            var result = new DiagnosticResult(UsingDeclarationAnalyzer.Rule)
+                .WithSpan("", 10, 13, 10 ,42);
+
+            await Verify.VerifyAnalyzerAsync(UsingDeclaration, result);
+        }
+
+        [Test]
+        public async Task IgnoresUsingBlockWithBraces()
+        {
+            await Verify.VerifyAnalyzerAsync(UsingBlockWithBraces);
+        }
+
+        [Test]
+        public async Task IgnoresUsingBlockWithoutBraces()
+        {
+            await Verify.VerifyAnalyzerAsync(UsingBlockWithoutBraces);
+        }
+
+        const string UsingBlockWithBraces = @"
 using System;
 
 namespace TheNamespace
@@ -21,25 +41,46 @@ namespace TheNamespace
         {
             using (var boo = new BooDis())
             {
-                int foo = 5;
+                Console.Write(3);
             }
 
-            var bar = 7;
+            Console.Write(7);
         }
-
 
         class BooDis : IDisposable
         {
             public void Dispose()
             {
-
             }
         }
     }       
-}
-";
+}";
 
-        static string usingDeclaration = @"
+        const string UsingBlockWithoutBraces = @"
+using System;
+
+namespace TheNamespace
+{
+    public class FooBar
+    {
+        public void Baz()
+        {
+            using (var boo = new BooDis())
+                Console.Write(3);
+
+            Console.Write(7);
+        }
+
+        class BooDis : IDisposable
+        {
+            public void Dispose()
+            {
+            }
+        }
+    }       
+}";
+
+        const string UsingDeclaration = @"
 using System;
 
 namespace TheNamespace
@@ -50,41 +91,20 @@ namespace TheNamespace
         {
             using var yah = new BooDis();
             {
-                int foo = 5;
+                Console.Write(3);
             }
 
-            var bar = 7;
+            Console.Write(7);
         }
-
 
         class BooDis : IDisposable
         {
             public void Dispose()
             {
-
             }
         }
     }       
-}
-";
-        [Test]
-        public async Task DetectsEnumParseThatDoesNotSpecifyTheCasing()
-        {
-            var source = usingDeclaration;
-
-            var result = new DiagnosticResult(UsingDeclarationAnalyzer.Rule)
-                .WithSpan("", 10, 13, 10 ,42);
-
-            await Verify.VerifyAnalyzerAsync(source, result);
-        }
-
-        [Test]
-        public async Task IgnoresEnumParseThatDoesSpecifiesTheCasing()
-        {
-            var source = usingBlock;
-
-            await Verify.VerifyAnalyzerAsync(source);
-        }
+}";
     }
 }
 

--- a/source/Tests/UsingDeclarationAnalyzerFixture.cs
+++ b/source/Tests/UsingDeclarationAnalyzerFixture.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Text;
+using NUnit.Framework;
+using Octopus.RoslynAnalyzers;
+using Verify = Microsoft.CodeAnalysis.CSharp.Testing.NUnit.AnalyzerVerifier<Octopus.RoslynAnalyzers.UsingDeclarationAnalyzer>;
+
+namespace Tests
+{
+    public class UsingDeclarationAnalyzerFixture
+    {
+        static string usingBlock = @"
+using System;
+
+namespace TheNamespace
+{
+    public class FooBar
+    {
+        public void Baz()
+        {
+            using (var boo = new BooDis())
+            {
+                int foo = 5;
+            }
+
+            var bar = 7;
+        }
+
+
+        class BooDis : IDisposable
+        {
+            public void Dispose()
+            {
+
+            }
+        }
+    }       
+}
+";
+
+        static string usingDeclaration = @"
+using System;
+
+namespace TheNamespace
+{
+    public class FooBar
+    {
+        public void Baz()
+        {
+            using var yah = new BooDis();
+            {
+                int foo = 5;
+            }
+
+            var bar = 7;
+        }
+
+
+        class BooDis : IDisposable
+        {
+            public void Dispose()
+            {
+
+            }
+        }
+    }       
+}
+";
+        [Test]
+        public async Task DetectsEnumParseThatDoesNotSpecifyTheCasing()
+        {
+            var source = usingDeclaration;
+
+            var result = new DiagnosticResult(UsingDeclarationAnalyzer.Rule)
+                .WithSpan("", 10, 13, 10 ,42);
+
+            await Verify.VerifyAnalyzerAsync(source, result);
+        }
+
+        [Test]
+        public async Task IgnoresEnumParseThatDoesSpecifiesTheCasing()
+        {
+            var source = usingBlock;
+
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+    }
+}
+


### PR DESCRIPTION
In #team-cloud-platform, we found that the new [using declarations](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-8.0/using#using-declaration) were encouraging us to hold onto `IDisposable`s for longer than intended because the scope/lifetime is not explicit.

[Conversation](https://octopusdeploy.slack.com/archives/CTZT49JFJ/p1650425431369829) in #topic-architecture shows other people have run into the same problem

This PR adds an analyzer that nudges you back to the old style with the more explicit scope. Projects can mute this using [rulesets](https://github.com/OctopusDeploy/OctopusDeploy/blob/master/source/Octopus.Upgraders/Octopus.ruleset) if desired

![image](https://user-images.githubusercontent.com/2888279/165206463-cba2efef-922d-4ade-a2a3-8ce92b4f135d.png)

https://trello.com/c/rHOyiGpN/1000-ban-using-without-block