### PR TITLE
Analyzer to prevent Builders re-assigning back to their state in the Build Methods

### DIFF
--- a/source/RoslynAnalyzers/BuildersReassigningToMemberVariablesAnalyzer.cs
+++ b/source/RoslynAnalyzers/BuildersReassigningToMemberVariablesAnalyzer.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Octopus.RoslynAnalyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class BuildersReassigningToMemberVariablesAnalyzer : DiagnosticAnalyzer
+    {
+        const string DiagnosticId = "Octopus_PreventBuildersReassigningToMemberVariablesFromBuild";
+
+        const string Title = "Reassigning of member variable in builder";
+
+        const string MessageFormat = "Builders should be state bags and not reassign values back to the state when building";
+        const string Category = "Octopus";
+
+        const string Description = @"What goes here?.";
+
+        internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Error,
+            true,
+            Description
+        );
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+        
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(CheckNaming, SyntaxKind.MethodDeclaration);
+        }
+
+        static void CheckNaming(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Node is MethodDeclarationSyntax { Body: { }, Identifier: { Value: "Build" } } method)
+            {
+                var expressionStatements = method.Body.Statements.Where(x => x is ExpressionStatementSyntax).Cast<ExpressionStatementSyntax>();
+                var assignmentStatements = expressionStatements.Where(x => x.Expression is AssignmentExpressionSyntax);
+
+                foreach (var assignmentStatement in assignmentStatements)
+                {
+                    var diagnostic = Diagnostic.Create(Rule, assignmentStatement.GetLocation());
+                    context.ReportDiagnostic(diagnostic);
+                }
+            }
+        }
+
+    }
+}

--- a/source/RoslynAnalyzers/BuildersReassigningToMemberVariablesAnalyzer.cs
+++ b/source/RoslynAnalyzers/BuildersReassigningToMemberVariablesAnalyzer.cs
@@ -43,7 +43,10 @@ namespace Octopus.RoslynAnalyzers
         {
             if (!(context.Node is MethodDeclarationSyntax { Body: { }, Identifier: { Value: "Build" } } method))
                 return;
-            
+
+            if (!(method.Parent is ClassDeclarationSyntax classDeclarationSyntax) || !classDeclarationSyntax.Identifier.ValueText.EndsWith("Builder"))
+                return;
+
             var localVariables = method.Body.Statements
                 .Where(x => x is LocalDeclarationStatementSyntax)
                 .Cast<LocalDeclarationStatementSyntax>()

--- a/source/RoslynAnalyzers/BuildersReassigningToMemberVariablesAnalyzer.cs
+++ b/source/RoslynAnalyzers/BuildersReassigningToMemberVariablesAnalyzer.cs
@@ -62,7 +62,13 @@ namespace Octopus.RoslynAnalyzers
 
             foreach (var assignmentStatement in assignmentStatements)
             {
+                
                 if (assignmentStatement.Left is IdentifierNameSyntax left && localVariables.Contains(left.Identifier.Value))
+                {
+                    //Local variable, let's allow reassignment to it as it doesn't modify the state of the builder
+                    continue;
+                }
+                if (assignmentStatement.Left is MemberAccessExpressionSyntax memberAccessExpression && memberAccessExpression.Expression is IdentifierNameSyntax identifier && localVariables.Contains(identifier.Identifier.Value))
                 {
                     //Local variable, let's allow reassignment to it as it doesn't modify the state of the builder
                     continue;

--- a/source/Tests/ReassigningMemberVariablesInBuilderAnalyzerFixture.cs
+++ b/source/Tests/ReassigningMemberVariablesInBuilderAnalyzerFixture.cs
@@ -10,6 +10,7 @@ namespace Tests
     public class ReassigningMemberVariablesInBuilderAnalyzerFixture
     {
         [TestCase("{|#0:Age ??= new AgeClass()|};")]
+        [TestCase("{|#0:Age = new AgeClass()|};")]
         [TestCase("{|#0:Age.age = 1|};")]
         public async Task ShouldNotAllowAssignmentBackToMemberVariable(string line)
         {
@@ -20,6 +21,8 @@ namespace Tests
 
         [TestCase("var someOtherLocalVariable = 10;\n" + "someOtherLocalVariable = 5;")]
         [TestCase("var someAge = new AgeClass();\nsomeAge.age = 1;")]
+        [TestCase("var (a, b) = (1, 2);")]
+        [TestCase("var (a, b, c, d) = (1, 2, 3, 4);")]
         public async Task ShouldAllowReassignmentOfLocalVariables(string line)
         {
             var source = GetSource(line);

--- a/source/Tests/ReassigningMemberVariablesInBuilderAnalyzerFixture.cs
+++ b/source/Tests/ReassigningMemberVariablesInBuilderAnalyzerFixture.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Testing;
 using NUnit.Framework;
@@ -45,6 +46,11 @@ namespace TheNamespace
 {
     public class SomethingSomethingBuilder
     {
+        class SomeClass
+        {   
+            public int X = 10;
+        }
+
         public int? Age {get; private set;}
 
         public SomethingSomethingBuilder WithAge(int age)
@@ -57,13 +63,16 @@ namespace TheNamespace
         {
             var someOtherLocalVariable = 10;
             someOtherLocalVariable = 5;
+            var someVector = new SomeClass();
+            someVector.X = 1;
             return Age;
         }
     }
 }
 ";
-
             await Verify.VerifyAnalyzerAsync(source);
         }
+        
+        
     }
 }

--- a/source/Tests/ReassigningMemberVariablesInBuilderAnalyzerFixture.cs
+++ b/source/Tests/ReassigningMemberVariablesInBuilderAnalyzerFixture.cs
@@ -26,12 +26,19 @@ namespace Tests
             await Verify.VerifyAnalyzerAsync(source);
         }
 
-        static string GetSource(string line)
+        [Test]
+        public async Task ShouldOnlyApplyRulesToClassesThatEndInBuilder()
+        {
+            var source = GetSource("Age ??= new AgeClass();", "NonBuilderClass");
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+
+        static string GetSource(string line, string className = "SomethingSomethingBuilder")
         {
             string source = @"
 namespace TheNamespace
 {
-    public class SomethingSomethingBuilder
+    public class " + className + @"
     {
         public class AgeClass
         {   
@@ -40,7 +47,7 @@ namespace TheNamespace
 
         public AgeClass? Age {get; private set;}
 
-        public SomethingSomethingBuilder WithAge(AgeClass age)
+        public " + className + @" WithAge(AgeClass age)
         {
             Age = age;
             return this;

--- a/source/Tests/ReassigningMemberVariablesInBuilderAnalyzerFixture.cs
+++ b/source/Tests/ReassigningMemberVariablesInBuilderAnalyzerFixture.cs
@@ -1,0 +1,41 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+using Octopus.RoslynAnalyzers;
+using Verify = Microsoft.CodeAnalysis.CSharp.Testing.NUnit.AnalyzerVerifier<Octopus.RoslynAnalyzers.BuildersReassigningToMemberVariablesAnalyzer>;
+
+namespace Tests
+{
+    public class ReassigningMemberVariablesInBuilderAnalyzerFixture
+    {
+        [Test]
+        public async Task ShouldNotAllow()
+        {
+            const string source = @"
+namespace TheNamespace
+{
+    public class SomethingSomethingBuilder
+    {
+        public int? Age {get; private set;}
+
+        public SomethingSomethingBuilder WithAge(int age)
+        {
+            Age = age;
+            return this;
+        }
+
+        public int? Build()
+        {
+            var someOtherLocalVariable = 10;
+            {|#0:Age ??= 10;|}
+            return Age;
+        }
+    }
+}
+";
+
+            var result = new DiagnosticResult(BuildersReassigningToMemberVariablesAnalyzer.Rule).WithLocation(0); 
+            await Verify.VerifyAnalyzerAsync(source, result);
+        }
+    }
+}


### PR DESCRIPTION
It was discussed recently that we have a lot of builders that assign back to their state during the `Build` method and we decided that this should not be the case. 

The builder should be a state bag of state _given_ to it, and when it Builds, it should build _new_ objects for all state required that wasn't assigned to it. This should not be assigned back to the builder, as next time `Build` is called on that builder, it should once against create _new_ objects for all the state required not assigned.

Example of incorrect usage of a Builder:

```
class FooBuilder
{
  string? bar;

  public FooBuilder(string bar)
  {
    this.bar = bar;
    return this;
  } 

  public Foo Build()
  {
    bar ??= Some.RandomString();
    return new Foo(bar);
  }
}
```

This is incorrect as it assigns back to bar, so if you call build twice you will get output like:

```
First Call: new Foo("abcdRandomString");
Second Call: new Foo("abcdRandomString");
```

In reality, the second time you call it, you should get a different random string.

A correct builder looks like:

```
class FooBuilder
{
  string? bar;

  public FooBuilder(string bar)
  {
    this.bar = bar;
    return this;
  } 

  public Foo Build()
  {
    var bar = this.bar ?? Some.RandomString();
    return new Foo(bar);
  }
}
```

See how a local variable was created, and we use the member variable if not null, otherwise we generate it. Now when we call `Build` twice we'd get outputs like:

```
First Call: new Foo("abcdRandomString");
Second Call: new Foo("zxywRandomString");
```

Each time `Build` is called, since we haven't given it state for `bar`, it gets generated with every call. This way each time we build, we're creating a new valid object.

Over in Octopus Server, I have a PR in the works to clean up the violations: https://github.com/OctopusDeploy/OctopusDeploy/pull/12524