### PR TITLE
Add long-running async task analyzer

### DIFF
--- a/source/RoslynAnalyzers/LongRunningTaskWithAsyncWorkloadAnalyzer.cs
+++ b/source/RoslynAnalyzers/LongRunningTaskWithAsyncWorkloadAnalyzer.cs
@@ -1,0 +1,102 @@
+﻿using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Octopus.RoslynAnalyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class LongRunningTaskWithAsyncWorkloadAnalyzer : DiagnosticAnalyzer
+    {
+        const string DiagnosticId = "Octopus_LongRunningTaskWithAsyncWorkload";
+        const string Category = "Octopus";
+        const string Title = "Creating long-running Tasks with an async workload";
+        const string Description = "Creating Tasks the LongRunning otions and an async workload can result in a new thread being created to run the task, which may exit unexpectedly. This can result in difficult to diagnose bugs. Use Task.Run instead.";
+        const string MessageFormat = "Creating long-running Tasks with an async workload can result in unexpected thread exits. Use Task.Run instead.";
+
+        internal static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            DiagnosticId,
+            Title,
+            MessageFormat,
+            Category,
+            DiagnosticSeverity.Error,
+            true,
+            Description);
+
+        const int LongRunningFlag = 2;
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(CheckForLongRunningTaskWithAsyncWorkload, SyntaxKind.InvocationExpression);
+        }
+
+        void CheckForLongRunningTaskWithAsyncWorkload(SyntaxNodeAnalysisContext context)
+        {
+            if (context.Compilation == null)
+                return;
+
+            var invocationNode = (InvocationExpressionSyntax)context.Node;
+
+            if (!(invocationNode.Expression is MemberAccessExpressionSyntax memberAccessExpression) ||
+                memberAccessExpression.Name.ToString() != nameof(Task.Factory.StartNew))
+            {
+                return;
+            }
+
+            if (!(context.SemanticModel.GetSymbolInfo(memberAccessExpression).Symbol is IMethodSymbol calledSymbol))
+            {
+                return;
+            }
+
+            var taskFactorySymbol = context.Compilation.GetTypeByMetadataName("System.Threading.Tasks.TaskFactory")!;
+            var taskCreationOptionsType = context.Compilation.GetTypeByMetadataName("System.Threading.Tasks.TaskCreationOptions")!;
+            var startNewMethods = from method in taskFactorySymbol.GetMembers(nameof(Task.Factory.StartNew)).OfType<IMethodSymbol>()
+                let optionsParam = method.Parameters.SingleOrDefault(p => p.Type.Equals(taskCreationOptionsType, SymbolEqualityComparer.Default))
+                where optionsParam != null && method.IsGenericMethod
+                select (method, method.Parameters.IndexOf(optionsParam));
+            var (calledMethod, optionsParamPos) = startNewMethods.FirstOrDefault(m => m.method.Equals(calledSymbol.ConstructedFrom, SymbolEqualityComparer.Default));
+            if (calledMethod == null)
+            {
+                return;
+            }
+
+            var argumentSyntax = invocationNode.ArgumentList.Arguments[optionsParamPos];
+            var argumentSymbol = context.SemanticModel.GetSymbolInfo(argumentSyntax.Expression).Symbol;
+            if (!IsLongRunningFlagSpecified(argumentSyntax, argumentSymbol))
+            {
+                return;
+            }
+
+            var workloadExpression = invocationNode.ArgumentList.Arguments[0].Expression;
+            if (context.SemanticModel.GetSymbolInfo(workloadExpression).Symbol is IMethodSymbol workloadSymbol && ReturnsATask(workloadSymbol))
+            {
+                var diagnostic = Diagnostic.Create(Rule, context.Node.GetLocation());
+                context.ReportDiagnostic(diagnostic);
+            }
+
+            static bool IsLongRunningFlagSpecified(ArgumentSyntax argumentSyntax, ISymbol? argumentSymbol)
+            {
+                if (argumentSymbol is ILocalSymbol { HasConstantValue: true } localSymbol)
+                    return ((int)(localSymbol.ConstantValue ?? 0) & LongRunningFlag) != 0;
+
+                return argumentSyntax.Expression.ToString().Contains("LongRunning");
+            }
+
+            bool ReturnsATask(IMethodSymbol methodSymbol)
+            {
+                var taskSymbol = context.Compilation!.GetTypeByMetadataName("System.Threading.Tasks.Task");
+                var taskOfTSymbol = context.Compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1");
+
+                return methodSymbol.ReturnType.Equals(taskSymbol, SymbolEqualityComparer.IncludeNullability) ||
+                    methodSymbol.ReturnType.Equals(taskOfTSymbol, SymbolEqualityComparer.IncludeNullability);
+            }
+        }
+    }
+}

--- a/source/Tests/LongRunningTaskWithAsyncWorkloadAnalyzerFixture.cs
+++ b/source/Tests/LongRunningTaskWithAsyncWorkloadAnalyzerFixture.cs
@@ -1,0 +1,388 @@
+﻿using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+using Octopus.RoslynAnalyzers;
+using Verify = Microsoft.CodeAnalysis.CSharp.Testing.NUnit.AnalyzerVerifier<Octopus.RoslynAnalyzers.LongRunningTaskWithAsyncWorkloadAnalyzer>;
+
+namespace Tests
+{
+    public class LongRunningTaskWithAsyncWorkloadAnalyzerFixture
+    {
+        [Test]
+        public async Task DetectsAsyncLambda()
+        {
+            var result = new DiagnosticResult(LongRunningTaskWithAsyncWorkloadAnalyzer.Rule)
+                .WithSpan(11, 19, 11, 99);
+            await Verify.VerifyAnalyzerAsync(AsyncLambda, result);
+        }
+        
+        [Test]
+        public async Task DetectsNonAsyncLambda()
+        {
+            var result = new DiagnosticResult(LongRunningTaskWithAsyncWorkloadAnalyzer.Rule)
+                .WithSpan(11, 19, 11, 87);
+            await Verify.VerifyAnalyzerAsync(NonAsyncLambda, result);
+        }
+
+        [Test]
+        public async Task DetectsDelegate()
+        {
+            var result = new DiagnosticResult(LongRunningTaskWithAsyncWorkloadAnalyzer.Rule)
+                .WithSpan(11, 19, 11, 79);
+            await Verify.VerifyAnalyzerAsync(Delegate, result);
+        }
+
+        [Test]
+        public async Task DetectsWithMultipleOptions()
+        {
+            var result = new DiagnosticResult(LongRunningTaskWithAsyncWorkloadAnalyzer.Rule)
+                .WithSpan(11, 19, 11, 173);
+            await Verify.VerifyAnalyzerAsync(MultipleOptions, result);
+        }
+
+        [Test]
+        public async Task DetectsWithAliasedTypeNames()
+        {
+            var result = new DiagnosticResult(LongRunningTaskWithAsyncWorkloadAnalyzer.Rule)
+                .WithSpan(12, 19, 12, 84);
+            await Verify.VerifyAnalyzerAsync(AliasedTypeNames, result);
+        }
+
+        [Test]
+        public async Task DetectsWithOptionsAsConstant()
+        {
+            var result = new DiagnosticResult(LongRunningTaskWithAsyncWorkloadAnalyzer.Rule)
+                .WithSpan(12, 19, 12, 75);
+            await Verify.VerifyAnalyzerAsync(OptionsAsConstant, result);
+        }
+
+        [Test]
+        public async Task DetectsWithOverloadWithTaskScheduler()
+        {
+            var result = new DiagnosticResult(LongRunningTaskWithAsyncWorkloadAnalyzer.Rule)
+                .WithSpan(12, 19, 12, 141);
+            await Verify.VerifyAnalyzerAsync(OverloadWithTaskScheduler, result);
+        }
+
+        [Test]
+        public async Task DetectsWithOverloadWithState()
+        {
+            var result = new DiagnosticResult(LongRunningTaskWithAsyncWorkloadAnalyzer.Rule)
+                .WithSpan(11, 19, 11, 113);
+            await Verify.VerifyAnalyzerAsync(OverloadWithState, result);
+        }
+
+        [Test]
+        public async Task DetectsWithOverloadWithStateAndTaskScheduler()
+        {
+            var result = new DiagnosticResult(LongRunningTaskWithAsyncWorkloadAnalyzer.Rule)
+                .WithSpan(12, 19, 12, 155);
+            await Verify.VerifyAnalyzerAsync(OverloadWithStateAndTaskScheduler, result);
+        }
+
+        [Test]
+        public async Task DoesNotReportWithOptionsAsVariable()
+        {
+            await Verify.VerifyAnalyzerAsync(OptionsAsVariable);
+        }
+
+        [Test]
+        public async Task DoesNotReportWhenNotLongRunning()
+        {
+            await Verify.VerifyAnalyzerAsync(NotLongRunning);
+        }
+
+        [Test]
+        public async Task DoesNotReportGoodUsage()
+        {
+            await Verify.VerifyAnalyzerAsync(GoodUsage);
+        }
+
+        [Test]
+        public async Task DoesNotReportIrrelevantMethods()
+        {
+            await Verify.VerifyAnalyzerAsync(SomeOtherMethodCalledStartNew);
+        }
+
+        const string AsyncLambda = @"
+using System;
+using System.Threading.Tasks;
+
+namespace TheNamespace
+{
+    public class FooBar
+    {
+        public async Task Baz()
+        {
+            await Task.Factory.StartNew(async () => await Blah(), TaskCreationOptions.LongRunning);
+        }
+
+        async Task Blah()
+        {
+            await Task.CompletedTask;
+        }
+    }
+}
+";
+
+        const string NonAsyncLambda = @"
+using System;
+using System.Threading.Tasks;
+
+namespace TheNamespace
+{
+    public class FooBar
+    {
+        public async Task Baz()
+        {
+            await Task.Factory.StartNew(() => Blah(), TaskCreationOptions.LongRunning);
+        }
+
+        async Task Blah()
+        {
+            await Task.CompletedTask;
+        }
+    }
+}
+";
+
+        const string Delegate = @"
+using System;
+using System.Threading.Tasks;
+
+namespace TheNamespace
+{
+    public class FooBar
+    {
+        public async Task Baz()
+        {
+            await Task.Factory.StartNew(Blah, TaskCreationOptions.LongRunning);
+        }
+
+        async Task Blah()
+        {
+            await Task.CompletedTask;
+        }
+    }
+}
+";
+
+        const string MultipleOptions = @"
+using System;
+using System.Threading.Tasks;
+
+namespace TheNamespace
+{
+    public class FooBar
+    {
+        public async Task Baz()
+        {
+            await Task.Factory.StartNew(async () => await Blah(), TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach | TaskCreationOptions.HideScheduler);
+        }
+
+        async Task Blah()
+        {
+            await Task.CompletedTask;
+        }
+    }
+}
+";
+
+        const string AliasedTypeNames = @"
+using System;
+using Tasky = System.Threading.Tasks.Task;
+using TCO = System.Threading.Tasks.TaskCreationOptions;
+
+namespace TheNamespace
+{
+    public class FooBar
+    {
+        public async Tasky Baz()
+        {
+            await Tasky.Factory.StartNew(async () => await Blah(), TCO.LongRunning);
+        }
+
+        async Tasky Blah()
+        {
+            await Tasky.CompletedTask;
+        }
+    }
+}
+";
+
+        const string OptionsAsConstant = @"
+using System;
+using System.Threading.Tasks;
+
+namespace TheNamespace
+{
+    public class FooBar
+    {
+        public async Task Baz()
+        {
+            const TaskCreationOptions options = TaskCreationOptions.LongRunning;
+            await Task.Factory.StartNew(async () => await Blah(), options);
+        }
+
+        async Task Blah()
+        {
+            await Task.CompletedTask;
+        }
+    }
+}
+";
+
+        const string OptionsAsVariable = @"
+using System;
+using System.Threading.Tasks;
+
+namespace TheNamespace
+{
+    public class FooBar
+    {
+        public async Task Baz()
+        {
+            var options = TaskCreationOptions.LongRunning;
+            await Task.Factory.StartNew(async () => await Blah(), options);
+        }
+
+        async Task Blah()
+        {
+            await Task.CompletedTask;
+        }
+    }
+}
+";
+
+        const string OverloadWithTaskScheduler = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TheNamespace
+{
+    public class FooBar
+    {
+        public async Task Baz(CancellationToken cancellationToken)
+        {
+            await Task.Factory.StartNew(async () => await Blah(), cancellationToken, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+        }
+
+        async Task Blah()
+        {
+            await Task.CompletedTask;
+        }
+    }
+}
+";
+
+        const string OverloadWithState = @"
+using System;
+using System.Threading.Tasks;
+
+namespace TheNamespace
+{
+    public class FooBar
+    {
+        public async Task Baz()
+        {
+            await Task.Factory.StartNew(async x => await Blah(x), new object(), TaskCreationOptions.LongRunning);
+        }
+
+        async Task Blah(object state)
+        {
+            await Task.CompletedTask;
+        }
+    }
+}
+";
+
+        const string OverloadWithStateAndTaskScheduler = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TheNamespace
+{
+    public class FooBar
+    {
+        public async Task Baz(CancellationToken cancellationToken)
+        {
+            await Task.Factory.StartNew(async x => await Blah(x), new object(), cancellationToken, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+        }
+
+        async Task Blah(object state)
+        {
+            await Task.CompletedTask;
+        }
+    }
+}
+";
+
+        const string NotLongRunning = @"
+using System;
+using System.Threading.Tasks;
+
+namespace TheNamespace
+{
+    public class FooBar
+    {
+        public async Task Baz()
+        {
+            await Task.Factory.StartNew(async () => await Blah(), TaskCreationOptions.DenyChildAttach);
+        }
+
+        async Task Blah()
+        {
+            await Task.CompletedTask;
+        }
+    }
+}
+";
+
+        const string GoodUsage = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TheNamespace
+{
+    public class FooBar
+    {
+        public async Task Baz()
+        {
+            await Task.Factory.StartNew(() => Blah(), TaskCreationOptions.LongRunning);
+        }
+
+        void Blah()
+        {
+            Thread.Sleep(10000);
+        }
+    }
+}
+";
+
+        const string SomeOtherMethodCalledStartNew = @"
+using System;
+
+namespace TheNamespace
+{
+    public class TaskFactory
+    {
+        public void StartNew()
+        {
+        }
+    }
+
+    public class FooBar
+    {
+        public void Baz()
+        {
+            var factory = new TaskFactory();
+            factory.StartNew();
+        }
+    }
+}
+";
+    }
+}


### PR DESCRIPTION
This analyzer won't allow starting async Tasks via `Task.Factory.StartNew` with the `TaskCreationOptions.LongRunning` flag specified. This can create issues where the initial task completes before expected and the created thread exits.

This was the cause behind the [SQL 995 issue](https://github.com/OctopusDeploy/Issues/issues/7089).