### PR TITLE
Implementation of OCT2008 analyzer

### DIFF
--- a/source/RoslynAnalyzers/Descriptors.cs
+++ b/source/RoslynAnalyzers/Descriptors.cs
@@ -74,5 +74,17 @@ namespace Octopus.RoslynAnalyzers
             "Integration test container classes should only be used to organise tests (because we must have 1 test per class for maximum parallel goodness,"
             + " any logic that you want to share across multiple tests should be in builders, class/assembly fixtures, or some other generic helper."
         );
+        
+        public static DiagnosticDescriptor Oct2008IntegrationTestForwardCancellationTokenToInvocations()
+        {
+            return new DiagnosticDescriptor("OCT2008",
+                "Integration test container classes should forward the 'CancellationToken' to methods that take one",
+                "Cancellation Token is defined in integration test base class. Container classes should forward the 'CancellationToken' to methods that take one",
+                "Octopus.Testing",
+                DiagnosticSeverity.Info,
+                false, // Testing analysers are disabled by default, these will only be enabled for test projects
+                "Forward the 'CancellationToken' parameter to methods that take one to ensure the operation cancellation notifications gets properly propagated, " 
+                + "or pass in 'CancellationToken.None' explicitly to indicate intentionally not propagating the token.");
+        }
     }
 }

--- a/source/RoslynAnalyzers/Descriptors.cs
+++ b/source/RoslynAnalyzers/Descriptors.cs
@@ -79,11 +79,11 @@ namespace Octopus.RoslynAnalyzers
         {
             return new DiagnosticDescriptor("OCT2008",
                 "Integration test container classes should forward the 'CancellationToken' to methods that take one",
-                "Cancellation Token is defined in integration test base class. Container classes should forward the 'CancellationToken' to methods that take one",
+                "Cancellation Token is defined in IntegrationTest base class. Container classes should forward the 'CancellationToken' to methods that take one",
                 "Octopus.Testing",
                 DiagnosticSeverity.Info,
                 false, // Testing analysers are disabled by default, these will only be enabled for test projects
-                "Forward the 'CancellationToken' parameter to methods that take one to ensure the operation cancellation notifications gets properly propagated, " 
+                "Forward the CancellationToken property to compatible methods to ensure cancellation notifications get properly propagated,"
                 + "or pass in 'CancellationToken.None' explicitly to indicate intentionally not propagating the token.");
         }
     }

--- a/source/RoslynAnalyzers/Testing/Constants.cs
+++ b/source/RoslynAnalyzers/Testing/Constants.cs
@@ -10,6 +10,9 @@ namespace Octopus.RoslynAnalyzers.Testing
             internal static readonly string UnitTest = "Octopus.IntegrationTests.UnitTest";
             internal static readonly string XunitFact = "Xunit.FactAttribute";
             internal static readonly string XunitTheory = "Xunit.TheoryAttribute";
+            internal static readonly string SystemThreadingCancellationToken = "System.Threading.CancellationToken";
+            internal static readonly string SystemThreadingTasksTask1 = "System.Threading.Tasks.Task`1";
+            internal static readonly string SystemThreadingTasksValueTask1 = "System.Threading.Tasks.ValueTask`1";
         }
     }
 }

--- a/source/RoslynAnalyzers/Testing/Integration/IntegrationTestForwardCancellationTokenToInvocationsAnalyzer.cs
+++ b/source/RoslynAnalyzers/Testing/Integration/IntegrationTestForwardCancellationTokenToInvocationsAnalyzer.cs
@@ -1,0 +1,271 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Octopus.RoslynAnalyzers.Testing.Integration
+{
+    /// <summary>
+    /// Specific analyzer for Octopus Integration Test container classes.
+    /// This will show "information" hint when method call can forward CancellationToken, but hasn't.
+    /// For Octopus Integration Test, CancellationToken is defined in the base class.
+    /// The existing dotnet analyzer, CA2016, handle cases where CancellationToken is found on the method context / containing class, but
+    /// not when definition is in parent class. (IE: IntegrationTest)
+    /// This implementation is based (heavily) on CA2016 implementation. (https://github.com/dotnet/roslyn-analyzers/pull/3641)
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class IntegrationTestForwardCancellationTokenToInvocationsAnalyzer : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+            Descriptors.Oct2008IntegrationTestForwardCancellationTokenToInvocations()
+        );
+
+        public override void Initialize(AnalysisContext analysisContext)
+        {
+            analysisContext.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            analysisContext.EnableConcurrentExecution();
+            analysisContext.RegisterCompilationStartAction(AnalyzeCompilationStart);
+        }
+
+        void AnalyzeCompilationStart(CompilationStartAnalysisContext compilationStartAnalysisContext)
+        {
+            compilationStartAnalysisContext.RegisterOperationAction(
+                context =>
+                {
+                    if (!IsOperationOfInterest(context))
+                    {
+                        return;
+                    }
+
+                    var (cancellationTokenType, genericTaskType, genericValueTaskType) = GetWellKnownTypes(context);
+                    if (cancellationTokenType == null)
+                    {
+                        // Only ct type matters, for the generic type it is ok to be null (edge case).
+                        return;
+                    }
+
+                    var invocation = (IInvocationOperation)context.Operation;
+                    var method = invocation.TargetMethod;
+
+                    // Verify that the current invocation is not passing an explicit token already
+                    if (IsCancellationTokenAlreadyForwarded(invocation.Arguments, cancellationTokenType))
+                    {
+                        return;
+                    }
+
+                    // Verify method has optional ct, warn user to be explicit rather than relying on default.
+                    if (InvocationMethodTakesAToken(method, invocation.Arguments, cancellationTokenType) ||
+
+                        // Verify method has ct overload as last parameter.
+                        InvocationMethodHasCancellationTokenOverload(method, cancellationTokenType, genericTaskType, genericValueTaskType))
+                    {
+                        SyntaxNode? nodeToDiagnose = GetInvocationMethodNameNode(context.Operation.Syntax) ?? context.Operation.Syntax;
+                        context.ReportDiagnostic(Diagnostic.Create(Descriptors.Oct2008IntegrationTestForwardCancellationTokenToInvocations(), nodeToDiagnose.GetLocation()));
+                    }
+                },
+                OperationKind.Invocation
+            );
+        }
+
+        static bool IsOperationOfInterest(OperationAnalysisContext context)
+        {
+            return context.ContainingSymbol is IMethodSymbol containingMethod &&
+
+                // Only interested in IntegrationTestType classes.
+                containingMethod.ContainingType.IsAssignableTo(new OctopusTestingContext(context.Compilation).IntegrationTestType) &&
+
+                // No diagnostic on static method, this is handled by CA2016 and Octopus async-cancellation-token convention.
+                !containingMethod.IsStatic;
+        }
+
+        static (INamedTypeSymbol? cancellationTokenType, INamedTypeSymbol? genericTaskType, INamedTypeSymbol? genericValueTaskType) GetWellKnownTypes(OperationAnalysisContext context)
+        {
+            INamedTypeSymbol? cancellationTokenType = context.Compilation.GetTypeByMetadataName(Constants.Types.SystemThreadingCancellationToken);
+            INamedTypeSymbol? genericTaskType = context.Compilation.GetTypeByMetadataName(Constants.Types.SystemThreadingTasksTask1);
+            INamedTypeSymbol? genericValueTaskType = context.Compilation.GetTypeByMetadataName(Constants.Types.SystemThreadingTasksValueTask1);
+
+            return (cancellationTokenType, genericTaskType, genericValueTaskType);
+        }
+
+        static bool AnyArgument(ImmutableArray<IArgumentOperation> arguments, Func<IArgumentOperation, bool> predicate)
+        {
+            for (int i = arguments.Length - 1; i >= 0; i--)
+            {
+                if (predicate(arguments[i]))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        static bool IsCancellationTokenAlreadyForwarded(ImmutableArray<IArgumentOperation> invocationArguments, INamedTypeSymbol? cancellationTokenType)
+        {
+            // Scanning argument for explicitly declared cancellation token type. We want to show diagnostic for implicit (default / optional) case.
+            return AnyArgument(invocationArguments, argument => SymbolEqualityComparer.Default.Equals(argument.Parameter.Type, cancellationTokenType) && !argument.IsImplicit);
+        }
+
+        // Checks if the invocation has an optional ct argument at the end.
+        static bool InvocationMethodTakesAToken(IMethodSymbol method, ImmutableArray<IArgumentOperation> arguments, ISymbol cancellationTokenType)
+        {
+            return
+                !method.Parameters.IsEmpty &&
+                method.Parameters[method.Parameters.Length - 1] is { } lastParameter &&
+                InvocationIgnoresOptionalCancellationToken(lastParameter, arguments, cancellationTokenType);
+        }
+
+        // Check if the currently used overload is the one that takes the ct, but is utilizing the default value offered in the method signature.
+        // We want to offer a diagnostic for this case, so the user explicitly passes the ancestor's ct.
+        static bool InvocationIgnoresOptionalCancellationToken(
+            IParameterSymbol parameter,
+            ImmutableArray<IArgumentOperation> arguments,
+            ISymbol cancellationTokenType)
+        {
+            if (SymbolEqualityComparer.Default.Equals(parameter.Type, cancellationTokenType) &&
+                parameter.IsOptional) // Has a default value being used
+            {
+                // Find out if the ct argument is using the default value
+                // Need to check among all arguments in case the user is passing them named and unordered (despite the ct being defined as the last parameter)
+                return AnyArgument(
+                    arguments,
+                    a => SymbolEqualityComparer.Default.Equals(a.Parameter.Type, cancellationTokenType) && a.ArgumentKind == ArgumentKind.DefaultValue
+                );
+            }
+
+            return false;
+        }
+
+        // Check if there's a method overload with the same parameters as this one, in the same order, plus a ct at the end.
+        static bool InvocationMethodHasCancellationTokenOverload(
+            IMethodSymbol method,
+            ISymbol cancellationTokenType,
+            INamedTypeSymbol? genericTask,
+            INamedTypeSymbol? genericValueTask)
+        {
+            var overload = method.ContainingType
+                .GetMembers(method.Name)
+                .OfType<IMethodSymbol>()
+                .FirstOrDefault(
+                    methodToCompare => HasSameParametersPlusCancellationToken(
+                        cancellationTokenType,
+                        genericTask,
+                        genericValueTask,
+                        method,
+                        methodToCompare
+                    )
+                );
+
+            return overload != null;
+
+            // Checks if the parameters of the two passed methods only differ in a ct.
+            static bool HasSameParametersPlusCancellationToken(
+                ISymbol cancellationTokenType,
+                INamedTypeSymbol? genericTask,
+                INamedTypeSymbol? genericValueTask,
+                IMethodSymbol originalMethod,
+                IMethodSymbol methodToCompare)
+            {
+                // Avoid comparing to itself, or when there is no ct parameter, or when the last parameter is not a ct
+                if (SymbolEqualityComparer.Default.Equals(originalMethod, methodToCompare) ||
+                    methodToCompare.Parameters.Count(p => SymbolEqualityComparer.Default.Equals(p.Type, cancellationTokenType)) != 1 ||
+                    !SymbolEqualityComparer.Default.Equals(methodToCompare.Parameters[methodToCompare.Parameters.Length - 1].Type, cancellationTokenType))
+                {
+                    return false;
+                }
+
+                IMethodSymbol originalMethodWithAllParameters = (originalMethod.ReducedFrom ?? originalMethod).OriginalDefinition;
+                IMethodSymbol methodToCompareWithAllParameters = (methodToCompare.ReducedFrom ?? methodToCompare).OriginalDefinition;
+
+                // Ensure parameters only differ by one - the ct
+                if (originalMethodWithAllParameters.Parameters.Length != methodToCompareWithAllParameters.Parameters.Length - 1)
+                {
+                    return false;
+                }
+
+                // Now compare the types of all parameters before the ct
+                // The largest i is the number of parameters in the method that has fewer parameters
+                for (int i = 0; i < originalMethodWithAllParameters.Parameters.Length; i++)
+                {
+                    IParameterSymbol originalParameter = originalMethodWithAllParameters.Parameters[i];
+                    IParameterSymbol comparedParameter = methodToCompareWithAllParameters.Parameters[i];
+                    if (!SymbolEqualityComparer.Default.Equals(originalParameter.Type, comparedParameter.Type))
+                    {
+                        return false;
+                    }
+                }
+
+                // Overload is valid if its return type is implicitly convertable
+                var toCompareReturnType = methodToCompareWithAllParameters.ReturnType;
+                var originalReturnType = originalMethodWithAllParameters.ReturnType;
+                if (!toCompareReturnType.IsAssignableTo(originalReturnType))
+                {
+                    // Generic Task-like types are special since awaiting them essentially erases the task-like type.
+                    // If both types are Task-like we will warn if their generic arguments are convertable to each other.
+                    if (IsTaskLikeType(originalReturnType) && IsTaskLikeType(toCompareReturnType) &&
+                        originalReturnType is INamedTypeSymbol originalNamedType &&
+                        toCompareReturnType is INamedTypeSymbol toCompareNamedType &&
+                        TypeArgumentsAreConvertable(originalNamedType, toCompareNamedType))
+                    {
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                return true;
+
+                bool IsTaskLikeType(ITypeSymbol typeSymbol)
+                {
+                    if (genericTask != null &&
+                        SymbolEqualityComparer.Default.Equals(typeSymbol.OriginalDefinition, genericTask))
+                    {
+                        return true;
+                    }
+
+                    if (genericValueTask != null &&
+                        SymbolEqualityComparer.Default.Equals(typeSymbol.OriginalDefinition, genericValueTask))
+                    {
+                        return true;
+                    }
+
+                    return false;
+                }
+
+                bool TypeArgumentsAreConvertable(INamedTypeSymbol left, INamedTypeSymbol right)
+                {
+                    // left and right return type should be consistent.
+                    if (left.Arity != 1 ||
+                        right.Arity != 1 ||
+                        left.Arity != right.Arity)
+                    {
+                        return false;
+                    }
+
+                    var leftTypeArgument = left.TypeArguments.FirstOrDefault();
+                    var rightTypeArgument = right.TypeArguments.FirstOrDefault();
+                    return leftTypeArgument != null && rightTypeArgument != null && leftTypeArgument.GetType().IsInstanceOfType(rightTypeArgument);
+                }
+            }
+        }
+
+        static SyntaxNode? GetInvocationMethodNameNode(SyntaxNode invocationNode)
+        {
+            if (!(invocationNode is InvocationExpressionSyntax invocationExpression))
+                return null;
+
+            if (invocationExpression.Expression is MemberBindingExpressionSyntax memberBindingExpression)
+            {
+                // When using nullability features, specifically attempting to dereference possible null references,
+                // the dot becomes part of the member invocation expression, so we need to return just the name,
+                // so that the diagnostic gets properly returned in the method name only.
+                return memberBindingExpression.Name;
+            }
+
+            return invocationExpression.Expression;
+        }
+    }
+}

--- a/source/Tests/Testing/Integration/IntegrationTestForwardCancellationTokenToInvocationsAnalyzerFixture.cs
+++ b/source/Tests/Testing/Integration/IntegrationTestForwardCancellationTokenToInvocationsAnalyzerFixture.cs
@@ -1,0 +1,426 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+using Octopus.RoslynAnalyzers;
+using Verify = Tests.CSharpVerifier<Octopus.RoslynAnalyzers.Testing.Integration.IntegrationTestForwardCancellationTokenToInvocationsAnalyzer>;
+
+namespace Tests.Testing.Integration
+{
+    public class IntegrationTestForwardCancellationTokenToInvocationsAnalyzerFixture
+    {
+        [TestCase]
+        public async Task No_Diagnostic_ClassesThatHaveNothingToDoWithThisAnalyser()
+        {
+            const string container = @"
+public class JustAClassSittingAroundDoingItsThing
+{
+    async Task M()
+    {
+        await {|#0:MethodAsync|}();        
+    }
+
+    Task MethodAsync() => Task.CompletedTask;
+    Task MethodAsync(CancellationToken c) => Task.CompletedTask;
+
+}
+";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+        
+        [TestCase]
+        public async Task No_Diagnostic_NoCancellationTokenSupport()
+        {
+            const string container = @"
+public class TestClass : IntegrationTest
+{
+    async Task M()
+    {
+        await {|#0:MethodAsync|}();
+    }
+
+    Task MethodAsync() => Task.CompletedTask;
+}
+";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+
+        [TestCase]
+        public async Task No_Diagnostic_CancellationTokenIsAlreadyForwarded()
+        {
+            const string container = @"
+public class TestClass : IntegrationTest
+{
+    async Task M()
+    {
+        await {|#0:MethodAsync|}(CancellationToken);
+    }
+    
+    Task MethodAsync(CancellationToken ct) => Task.CompletedTask;
+}
+";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+
+        [TestCase]
+        public async Task No_Diagnostic_ExplicitDefaultCancellationToken()
+        {
+            const string container = @"
+public class TestClass : IntegrationTest
+{
+    async Task M()
+    {
+        await {|#0:MethodAsync|}(default);
+    }
+    
+    Task MethodAsync(CancellationToken ct) => Task.CompletedTask;
+}
+";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+
+        [TestCase]
+        public async Task No_Diagnostic_ExplicitNoneCancellationToken()
+        {
+            const string container = @"
+public class TestClass : IntegrationTest
+{
+    async Task M()
+    {
+        await {|#0:MethodAsync|}(CancellationToken.None);
+    }
+    
+    Task MethodAsync(CancellationToken ct) => Task.CompletedTask;
+}
+";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+
+        [TestCase]
+        public async Task No_Diagnostic_OverloadWithMultipleCancellationTokenParameters()
+        {
+            const string container = @"
+public class TestClass : IntegrationTest
+{
+    async Task M()
+    {
+        await {|#0:MethodAsync|}();
+    }
+    
+    Task MethodAsync() => Task.CompletedTask;
+    Task MethodAsync(CancellationToken ct1, CancellationToken ct2) => Task.CompletedTask;
+}
+";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+
+        [TestCase]
+        public async Task No_Diagnostic_CancellationTokenIsNotLastParameterOnOverload()
+        {
+            const string container = @"
+public class TestClass : IntegrationTest
+{
+    async Task M()
+    {
+        await {|#0:MethodAsync|}(""any"", ""thing"");
+    }
+
+    Task MethodAsync(string a, string b) => Task.CompletedTask;
+    Task MethodAsync(string a, CancellationToken ct, string b) => Task.CompletedTask;
+}
+";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+        
+        [TestCase]
+        public async Task No_Diagnostic_OverloadShouldHaveExactParameterSequencePlusCancellationToken()
+        {
+            const string container = @"
+public class TestClass : IntegrationTest
+{
+    async Task M()
+    {
+        await {|#0:MethodAsync|}(""any"");
+    }
+
+    Task MethodAsync(string a) => Task.CompletedTask;
+    Task MethodAsync(string a, string b, CancellationToken ct) => Task.CompletedTask;
+}
+";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+        
+        [TestCase]
+        public async Task No_Diagnostic_OverloadShouldHaveExactParameterTypePlusCancellationToken()
+        {
+            const string container = @"
+public class TestClass : IntegrationTest
+{
+    async Task M()
+    {
+        await {|#0:MethodAsync|}(""any"");
+    }
+
+    Task MethodAsync(string a) => Task.CompletedTask;
+    Task MethodAsync(int a, CancellationToken ct) => Task.CompletedTask;
+}
+";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+        
+        [TestCase]
+        public async Task No_Diagnostic_TokenForwardedWithUnorderedNamedParameter()
+        {
+            const string container = @"
+public class TestClass : IntegrationTest
+{
+    async Task M()
+    {
+        await {|#0:MethodAsync|}(ct: CancellationToken, a: ""any"");
+    }
+
+    Task MethodAsync(string a) => Task.CompletedTask;
+    Task MethodAsync(string a, CancellationToken ct) => Task.CompletedTask;
+}
+";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+        
+        [TestCase]
+        public async Task No_Diagnostic_ExtensionMethodTakesTokenAsync()
+        {
+            const string container = @"
+public class TestClass : IntegrationTest
+{
+    async Task M()
+    {
+        await {|#0:new MyClass()|}.MyMethod(""any"");
+    }
+}
+public class MyClass
+{
+    public Task MyMethod(string a) => Task.CompletedTask;
+}
+public static class Extensions
+{
+    public static Task MyMethod(this MyClass mc, CancellationToken c) => Task.CompletedTask;
+}
+";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+        
+        [TestCase]
+        public async Task No_Diagnostic_StaticMethodBoundary()
+        {
+            const string container = @"
+public class TestClass : IntegrationTest
+{
+    public static async Task M()
+    {
+        await InnerMethod();                
+
+        Task InnerMethod(CancellationToken ct = default) => Task.CompletedTask;
+    }
+}
+";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+        
+        [TestCase]
+        public async Task No_Diagnostic_OverloadReturnTypeDiffers()
+        {
+            const string container = @"
+public class TestClass : IntegrationTest
+{
+    async Task M()
+    {
+        await {|#0:Method|}(a: ""any"");
+    }
+
+    Task Method(string a) => Task.CompletedTask;
+    int Method(string a, CancellationToken ct) { throw new NotImplementedException(); }
+}
+";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+        
+        [TestCase]
+        public async Task Diagnostic_MethodWithCancellationTokenOverload()
+        {
+            var container = @"
+public class TestClass : IntegrationTest
+{
+    async Task M()
+    {
+        await {|#0:MethodAsync|}();        
+    }
+
+    Task MethodAsync() => Task.CompletedTask;
+    Task MethodAsync(CancellationToken c) => Task.CompletedTask;
+
+}
+";
+            var result = new DiagnosticResult(Descriptors.Oct2008IntegrationTestForwardCancellationTokenToInvocations()).WithLocation(0);
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(), result);
+        }
+        
+        [TestCase]
+        public async Task Diagnostic_TaskStoredAsVariable()
+        {
+            var container = @"
+public class TestClass : IntegrationTest
+{
+    async Task M()
+    {
+        Task t = {|#0:MethodAsync|}();
+        await t;        
+    }
+
+    Task MethodAsync() => Task.CompletedTask;
+    Task MethodAsync(CancellationToken c) => Task.CompletedTask;
+
+}
+";
+            var result = new DiagnosticResult(Descriptors.Oct2008IntegrationTestForwardCancellationTokenToInvocations()).WithLocation(0);
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(), result);
+        }
+
+        [TestCase]
+        public async Task Diagnostic_ExternalMethodWithCancellationTokenOverload()
+        {
+            var container = @"
+public class ExternalReference
+{
+    public Task MethodAsync() => Task.CompletedTask;
+    public Task MethodAsync(CancellationToken c) => Task.CompletedTask;
+}
+
+public class TestClass : IntegrationTest
+{
+    async Task M()
+    {
+        var ext = new ExternalReference();
+        await {|#0:ext.MethodAsync|}();        
+    }
+}
+";
+            var result = new DiagnosticResult(Descriptors.Oct2008IntegrationTestForwardCancellationTokenToInvocations()).WithLocation(0);
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(), result);
+        }
+
+        [TestCase]
+        public async Task Diagnostic_OverloadForOptionalParameters()
+        {
+            const string container = @"
+public class TestClass : IntegrationTest
+{
+    async Task M()
+    {
+        await {|#0:MethodAsync|}(""any"");
+        await {|#1:MethodAsync|}(""any"", ""thing"", ""again"");
+    }
+
+    Task MethodAsync(string a, string b = null, Object c = null) => Task.CompletedTask;
+    Task MethodAsync(string a, CancellationToken ct) => Task.CompletedTask;    
+    Task MethodAsync(string a, string b, Object c, CancellationToken ct) => Task.CompletedTask;
+}
+";
+            var result0 = new DiagnosticResult(Descriptors.Oct2008IntegrationTestForwardCancellationTokenToInvocations()).WithLocation(0);
+            var result1 = new DiagnosticResult(Descriptors.Oct2008IntegrationTestForwardCancellationTokenToInvocations()).WithLocation(1);
+            
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(), result0, result1);
+        }
+        
+        [TestCase]
+        public async Task Diagnostic_UnorderedNamedParameters()
+        {
+            var container = @"
+public class TestClass : IntegrationTest
+{
+    async Task M()
+    {
+        await {|#0:MethodAsync|}(z: ""Hello world"", x: 5, y: true);            
+    }
+
+    Task MethodAsync(int x, bool y = default, string z = """") => Task.CompletedTask;
+    Task MethodAsync(int x, bool y = default, string z = """", CancellationToken c = default) => Task.CompletedTask;
+}
+";
+            var result = new DiagnosticResult(Descriptors.Oct2008IntegrationTestForwardCancellationTokenToInvocations()).WithLocation(0);
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(), result);
+        }
+        
+        [TestCase]
+        public async Task Diagnostic_LocalStaticMethod()
+        {
+            // This will be a surprise, as directly passing CancellationToken (from IntegrationTest) is not a valid code (static context).
+            // The intention is to notify user and user should fix by adding CancellationToken parameter on the static method. 
+            var container = @"
+public class TestClass : IntegrationTest
+{
+    public static Task MethodAsync(int i, CancellationToken c = default) => Task.CompletedTask;
+    public async Task M()
+    {
+        await LocalStaticMethod();
+        static Task LocalStaticMethod()
+        {
+            return {|#0:MethodAsync|}(5);
+        }
+    }
+}
+";
+            var result = new DiagnosticResult(Descriptors.Oct2008IntegrationTestForwardCancellationTokenToInvocations()).WithLocation(0);
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(), result);
+        }
+        
+        [TestCase]
+        public async Task Diagnostic_ExternalGenericTypeMethod()
+        {
+            // This will be a surprise, as directly passing CancellationToken (from IntegrationTest) is not a valid code (static context).
+            // The intention is to notify user and user should fix by adding CancellationToken parameter on the static method. 
+            var container = @"
+
+public class AccountResource {}
+public class BasicRepository<TResource> where TResource : class
+{
+    public async Task<TResource> Get(string idOrHref) { throw new NotImplementedException(); } 
+    public async Task<TResource> Get(string idOrHref, CancellationToken cancellationToken) { throw new NotImplementedException(); }
+}
+
+public class TestClass : IntegrationTest
+{
+    public async Task M(BasicRepository<AccountResource> repository)
+    {
+        var accountResource = await {|#0:repository.Get|}(""id""); 
+    }
+}
+";
+            var result = new DiagnosticResult(Descriptors.Oct2008IntegrationTestForwardCancellationTokenToInvocations()).WithLocation(0);
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(), result);
+        }
+        
+        [TestCase]
+        public async Task Diagnostic_GenericWhereTypeIsErased()
+        {
+            // This will be a surprise, as directly passing CancellationToken (from IntegrationTest) is not a valid code (static context).
+            // The intention is to notify user and user should fix by adding CancellationToken parameter on the static method. 
+            var container = @"
+
+public class Reader
+{
+    public Task<T> Read<T>(int i) => Task.FromResult(default(T));
+    public Task<T> Read<T>(int i, CancellationToken ct = default) => Task.FromResult(default(T));
+}
+
+public class TestClass : IntegrationTest
+{
+    public async Task<int> M(Reader reader)
+    {
+        return await {|#0:reader.Read<int>|}(1); 
+    }
+}
+";
+            var result = new DiagnosticResult(Descriptors.Oct2008IntegrationTestForwardCancellationTokenToInvocations()).WithLocation(0);
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(), result);
+        }
+    }
+}

--- a/source/Tests/Testing/Integration/IntegrationTestForwardCancellationTokenToInvocationsAnalyzerFixture.cs
+++ b/source/Tests/Testing/Integration/IntegrationTestForwardCancellationTokenToInvocationsAnalyzerFixture.cs
@@ -9,7 +9,7 @@ namespace Tests.Testing.Integration
     public class IntegrationTestForwardCancellationTokenToInvocationsAnalyzerFixture
     {
         [TestCase]
-        public async Task No_Diagnostic_ClassesThatHaveNothingToDoWithThisAnalyser()
+        public async Task No_Diagnostic_ClassesThatHaveNothingToDoWithThisAnalyzer()
         {
             const string container = @"
 public class JustAClassSittingAroundDoingItsThing
@@ -21,7 +21,6 @@ public class JustAClassSittingAroundDoingItsThing
 
     Task MethodAsync() => Task.CompletedTask;
     Task MethodAsync(CancellationToken c) => Task.CompletedTask;
-
 }
 ";
             await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
@@ -246,7 +245,7 @@ public class TestClass : IntegrationTest
         [TestCase]
         public async Task Diagnostic_MethodWithCancellationTokenOverload()
         {
-            var container = @"
+            const string container = @"
 public class TestClass : IntegrationTest
 {
     async Task M()
@@ -266,7 +265,7 @@ public class TestClass : IntegrationTest
         [TestCase]
         public async Task Diagnostic_TaskStoredAsVariable()
         {
-            var container = @"
+            const string container = @"
 public class TestClass : IntegrationTest
 {
     async Task M()
@@ -287,7 +286,7 @@ public class TestClass : IntegrationTest
         [TestCase]
         public async Task Diagnostic_ExternalMethodWithCancellationTokenOverload()
         {
-            var container = @"
+            const string container = @"
 public class ExternalReference
 {
     public Task MethodAsync() => Task.CompletedTask;
@@ -333,7 +332,7 @@ public class TestClass : IntegrationTest
         [TestCase]
         public async Task Diagnostic_UnorderedNamedParameters()
         {
-            var container = @"
+            const string container = @"
 public class TestClass : IntegrationTest
 {
     async Task M()
@@ -354,7 +353,7 @@ public class TestClass : IntegrationTest
         {
             // This will be a surprise, as directly passing CancellationToken (from IntegrationTest) is not a valid code (static context).
             // The intention is to notify user and user should fix by adding CancellationToken parameter on the static method. 
-            var container = @"
+            const string container = @"
 public class TestClass : IntegrationTest
 {
     public static Task MethodAsync(int i, CancellationToken c = default) => Task.CompletedTask;
@@ -377,7 +376,7 @@ public class TestClass : IntegrationTest
         {
             // This will be a surprise, as directly passing CancellationToken (from IntegrationTest) is not a valid code (static context).
             // The intention is to notify user and user should fix by adding CancellationToken parameter on the static method. 
-            var container = @"
+            const string container = @"
 
 public class AccountResource {}
 public class BasicRepository<TResource> where TResource : class
@@ -403,7 +402,7 @@ public class TestClass : IntegrationTest
         {
             // This will be a surprise, as directly passing CancellationToken (from IntegrationTest) is not a valid code (static context).
             // The intention is to notify user and user should fix by adding CancellationToken parameter on the static method. 
-            var container = @"
+            const string container = @"
 
 public class Reader
 {

--- a/source/Tests/Testing/TestingExtensionMethods.cs
+++ b/source/Tests/Testing/TestingExtensionMethods.cs
@@ -8,6 +8,8 @@ namespace Tests.Testing
         {
             return $@"
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Octopus.IntegrationTests
 {{
@@ -16,7 +18,11 @@ namespace Octopus.IntegrationTests
         public void Dispose() {{ }}
     }}
 
-    public abstract class IntegrationTest : LoggedTest {{ }}
+    public abstract class IntegrationTest : LoggedTest 
+    {{ 
+        readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+        public CancellationToken CancellationToken => cancellationTokenSource.Token;
+    }}
 
     public abstract class UnitTest : LoggedTest {{ }}
 }}


### PR DESCRIPTION
# Background

The dotnet roslyn analyzer supports [CA2016](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2016). However, this does not handle the case when `CancellationToken` is defined in `parent` class.

This work creates `OCT2008` - **Integration test container classes should forward the 'CancellationToken' to methods that take one**


# Results

## Previously
![Screen Shot 2022-09-28 at 3 44 45 pm](https://user-images.githubusercontent.com/15998611/192697544-e22cf389-b37c-450d-80a1-f8c85286f143.png)

## After

![Screen Shot 2022-09-28 at 3 47 37 pm](https://user-images.githubusercontent.com/15998611/192697900-bdac3a57-7053-44a1-958c-ca613a052638.png)
