### PR TITLE
Set build framework to net6.0

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -25,7 +25,7 @@ class Build : NukeBuild
     [Parameter("Branch name for OctoVersion to use to calculate the version number. Can be set via the environment variable " + CiBranchNameEnvVariable + ".", Name = CiBranchNameEnvVariable)]
     string BranchName { get; set; }
 
-    [OctoVersion(BranchParameter = nameof(BranchName), AutoDetectBranchParameter = nameof(AutoDetectBranch))] 
+    [OctoVersion(Framework = "net6.0", BranchParameter = nameof(BranchName), AutoDetectBranchParameter = nameof(AutoDetectBranch))] 
     public OctoVersionInfo OctoVersionInfo;
 
     AbsolutePath SourceDirectory => RootDirectory / "source";


### PR DESCRIPTION
The `OctoVersion` defaults to `net5.0` for build framework. This will work is to set it to `net6.0`

## Before
<img width="703" alt="Screen Shot 2022-09-30 at 9 29 33 am" src="https://user-images.githubusercontent.com/15998611/193159681-af93a31f-87ad-434f-98eb-6622a9f28f4b.png">


## After
![Screen Shot 2022-09-30 at 9 28 06 am](https://user-images.githubusercontent.com/15998611/193159507-a268e2ce-a05e-4f47-a8d6-9542e9a06ec2.png)
