### PR TITLE
OCT2008 Fixer

### DIFF
--- a/source/RoslynAnalyzers/RoslynAnalyzers.csproj
+++ b/source/RoslynAnalyzers/RoslynAnalyzers.csproj
@@ -27,12 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!--
-    Using this version is intentional!
-    The newer 4.3.0 version break under the 'dotnet build' chain when this is added as a nuget package to another project. (Tested under .NET 6.0.301/401)              
-    -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/source/RoslynAnalyzers/RoslynAnalyzers.csproj
+++ b/source/RoslynAnalyzers/RoslynAnalyzers.csproj
@@ -10,7 +10,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>RS2008</NoWarn>
-    <LangVersion>8</LangVersion>
+    <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- At the time of writing anything later than netstandard 2.0 doesn't work in Visual Studio -->
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -22,20 +22,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" />
-    <!--
-    Using this version is intentional!
-    The newer version(s) break under the 'dotnet build' chain when this is added as a nuget package to another project. (Tested under .NET 5.0.101)
-    Fails with versions:
-      Microsoft.CodeAnalysis.CSharp 3.8.0
-      Microsoft.CodeAnalysis.CSharp 3.3.9.0-4.21056.26
-    -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0" />
+    <None Update="tools\*.ps1" CopyToOutputDirectory="Always" Pack="true" PackagePath="" />
+    <None Visible="false" Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="tools\*.ps1" CopyToOutputDirectory="Always" Pack="true" PackagePath="" />
-    <None Visible="false" Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" />
+    <!--
+    Using this version is intentional!
+    The newer 4.3.0 version break under the 'dotnet build' chain when this is added as a nuget package to another project. (Tested under .NET 6.0.301/401)              
+    -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
   </ItemGroup>
 
 </Project>

--- a/source/RoslynAnalyzers/Testing/Integration/IntegrationTestForwardCancellationTokenToInvocationsFixer.cs
+++ b/source/RoslynAnalyzers/Testing/Integration/IntegrationTestForwardCancellationTokenToInvocationsFixer.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Octopus.RoslynAnalyzers.Testing.Integration
+{
+    /// <summary>
+    /// Provides light-bulb hint to fix diagnostic reported from <see cref="IntegrationTestForwardCancellationTokenToInvocationsAnalyzer"/>.
+    /// </summary>
+    /// <remarks>
+    /// This implementation is based (heavily) on CA2016 implementation. (https://github.com/dotnet/roslyn-analyzers/pull/3641)
+    /// </remarks>
+    [ExportCodeFixProvider(LanguageNames.CSharp)]
+    public sealed class IntegrationTestForwardCancellationTokenToInvocationsFixer : CodeFixProvider
+    {
+        const string CancellationTokenPropertiesName = "CancellationToken";
+
+        public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(
+            Descriptors.Oct2008IntegrationTestForwardCancellationTokenToInvocations().Id
+        );
+
+        public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var contextDocument = context.Document;
+            var cancellationToken = context.CancellationToken;
+            var contextRootNode = await contextDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+            if (contextRootNode is null)
+            {
+                return;
+            }
+
+            var invocationOperation = await GetInvocationOperation(contextDocument, contextRootNode, context.Span, cancellationToken);
+
+            if (invocationOperation is null)
+            {
+                return;
+            }
+
+            var (invocationSyntaxExpression, invocationSyntaxArguments) = GetExpressionAndArguments(invocationOperation.Syntax);
+
+            if (invocationSyntaxExpression is null)
+            {
+                return;
+            }
+
+            var properties = context.Diagnostics[0].Properties;
+
+            if (!properties.TryGetValue(IntegrationTestForwardCancellationTokenToInvocationsAnalyzer.OfferDiagnosticFix, out var offerDiagnosticFix)
+                || bool.FalseString.Equals(offerDiagnosticFix))
+            {
+                return;
+            }
+
+            Task<Document> CreateChangedDocument(CancellationToken _)
+            {
+                var newRoot = UpdatedRootWithCancellationTokenSyntax(
+                    contextDocument,
+                    contextRootNode,
+                    invocationOperation,
+                    invocationSyntaxExpression,
+                    invocationSyntaxArguments
+                );
+                var newDocument = contextDocument.WithSyntaxRoot(newRoot);
+
+                return Task.FromResult(newDocument);
+            }
+
+            var title = Descriptors.Oct2008IntegrationTestForwardCancellationTokenToInvocations().Title.ToString();
+            context.RegisterCodeFix(CodeAction.Create(title, CreateChangedDocument, equivalenceKey: title), context.Diagnostics);
+        }
+
+        static async Task<IInvocationOperation?> GetInvocationOperation(Document document, SyntaxNode rootNode, TextSpan span, CancellationToken cancellationToken)
+        {
+            IInvocationOperation? invocationOperation = null;
+            var offendingNode = rootNode.FindNode(span, getInnermostNodeForTie: true);
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+
+            if (semanticModel == null)
+            {
+                return invocationOperation;
+            }
+
+            // The analyzer created the diagnostic on the IdentifierNameSyntax, and the parent is the actual invocation
+            if (offendingNode.Parent != null)
+            {
+                SyntaxNode? nodeToRetrieve = null;
+
+                // When method is invoked using nullability, .?Method(), then the node.Parent.Parent is the actual invocation.
+                if (offendingNode.Parent.IsKind(SyntaxKind.MemberBindingExpression))
+                {
+                    nodeToRetrieve = offendingNode.Parent.Parent;
+                }
+
+                // Use Parent.Parent for MemberBindingExpression unless if it is null.
+                invocationOperation = semanticModel.GetOperation(nodeToRetrieve ?? offendingNode.Parent, cancellationToken) as IInvocationOperation;
+            }
+
+            return invocationOperation;
+        }
+
+        static (SyntaxNode? syntaxExpression, ImmutableArray<ArgumentSyntax> syntaxArguments) GetExpressionAndArguments(SyntaxNode invocationNode)
+        {
+            SyntaxNode? syntaxExpression = null;
+            var syntaxArguments = ImmutableArray<ArgumentSyntax>.Empty;
+
+            if (invocationNode is InvocationExpressionSyntax invocationExpression)
+            {
+                syntaxExpression = invocationExpression.Expression;
+                syntaxArguments = invocationExpression.ArgumentList.Arguments.ToImmutableArray();
+            }
+
+            return (syntaxExpression, syntaxArguments);
+        }
+
+        static SyntaxNode UpdatedRootWithCancellationTokenSyntax(
+            Document doc,
+            SyntaxNode root,
+            IOperation invocation,
+            SyntaxNode expression,
+            ImmutableArray<ArgumentSyntax> currentArguments)
+        {
+            var generator = SyntaxGenerator.GetGenerator(doc);
+            var ctArgumentSyntax = generator.Argument(generator.IdentifierName(CancellationTokenPropertiesName));
+            var newArguments = currentArguments.CastArray<SyntaxNode>();
+            newArguments = newArguments.Add(ctArgumentSyntax);
+
+            // Insert the new arguments to the new invocation
+            var newInvocationWithArguments = generator.InvocationExpression(expression, newArguments).WithTriviaFrom(invocation.Syntax);
+
+            return generator.ReplaceNode(root, invocation.Syntax, newInvocationWithArguments);
+        }
+    }
+}

--- a/source/Tests/Testing/Integration/IntegrationTestForwardCancellationTokenToInvocationsAnalyzerFixture.cs
+++ b/source/Tests/Testing/Integration/IntegrationTestForwardCancellationTokenToInvocationsAnalyzerFixture.cs
@@ -1,11 +1,17 @@
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
 using NUnit.Framework;
 using Octopus.RoslynAnalyzers;
-using Verify = Tests.CSharpVerifier<Octopus.RoslynAnalyzers.Testing.Integration.IntegrationTestForwardCancellationTokenToInvocationsAnalyzer>;
+using Octopus.RoslynAnalyzers.Testing.Integration;
 
 namespace Tests.Testing.Integration
 {
+    // Moving this inside namespace block to avoid having to use fqdn on references. (IE: Microsoft.CodeAnalysis.Testing.Verifiers, etc)
+    using Verify = CSharpCodeFixVerifier<IntegrationTestForwardCancellationTokenToInvocationsAnalyzer, 
+        IntegrationTestForwardCancellationTokenToInvocationsFixer, NUnitVerifier>;
+    
     public class IntegrationTestForwardCancellationTokenToInvocationsAnalyzerFixture
     {
         [TestCase]
@@ -16,7 +22,7 @@ public class JustAClassSittingAroundDoingItsThing
 {
     async Task M()
     {
-        await {|#0:MethodAsync|}();        
+        await {|#0:MethodAsync|}();
     }
 
     Task MethodAsync() => Task.CompletedTask;
@@ -206,24 +212,7 @@ public static class Extensions
 ";
             await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
         }
-        
-        [TestCase]
-        public async Task No_Diagnostic_StaticMethodBoundary()
-        {
-            const string container = @"
-public class TestClass : IntegrationTest
-{
-    public static async Task M()
-    {
-        await InnerMethod();                
 
-        Task InnerMethod(CancellationToken ct = default) => Task.CompletedTask;
-    }
-}
-";
-            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
-        }
-        
         [TestCase]
         public async Task No_Diagnostic_OverloadReturnTypeDiffers()
         {
@@ -241,16 +230,29 @@ public class TestClass : IntegrationTest
 ";
             await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
         }
-        
+
         [TestCase]
-        public async Task Diagnostic_MethodWithCancellationTokenOverload()
+        public async Task Diagnostic_WithFix_MethodWithCancellationTokenOverload()
         {
             const string container = @"
 public class TestClass : IntegrationTest
 {
     async Task M()
     {
-        await {|#0:MethodAsync|}();        
+        await {|#0:MethodAsync|}();
+    }
+
+    Task MethodAsync() => Task.CompletedTask;
+    Task MethodAsync(CancellationToken c) => Task.CompletedTask;
+
+}
+";
+            const string fixedCode = @"
+public class TestClass : IntegrationTest
+{
+    async Task M()
+    {
+        await {|#0:MethodAsync|}(CancellationToken);
     }
 
     Task MethodAsync() => Task.CompletedTask;
@@ -259,11 +261,11 @@ public class TestClass : IntegrationTest
 }
 ";
             var result = new DiagnosticResult(Descriptors.Oct2008IntegrationTestForwardCancellationTokenToInvocations()).WithLocation(0);
-            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(), result);
+            await Verify.VerifyCodeFixAsync(container.WithTestingTypes(), result, fixedCode.WithTestingTypes());
         }
-        
+
         [TestCase]
-        public async Task Diagnostic_TaskStoredAsVariable()
+        public async Task Diagnostic_WithFix_TaskStoredAsVariable()
         {
             const string container = @"
 public class TestClass : IntegrationTest
@@ -279,12 +281,26 @@ public class TestClass : IntegrationTest
 
 }
 ";
+            const string fixedCode = @"
+public class TestClass : IntegrationTest
+{
+    async Task M()
+    {
+        Task t = {|#0:MethodAsync|}(CancellationToken);
+        await t;        
+    }
+
+    Task MethodAsync() => Task.CompletedTask;
+    Task MethodAsync(CancellationToken c) => Task.CompletedTask;
+
+}
+";
             var result = new DiagnosticResult(Descriptors.Oct2008IntegrationTestForwardCancellationTokenToInvocations()).WithLocation(0);
-            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(), result);
+            await Verify.VerifyCodeFixAsync(container.WithTestingTypes(), result, fixedCode.WithTestingTypes());
         }
 
         [TestCase]
-        public async Task Diagnostic_ExternalMethodWithCancellationTokenOverload()
+        public async Task Diagnostic_WithFix_ExternalMethodWithCancellationTokenOverload()
         {
             const string container = @"
 public class ExternalReference
@@ -298,16 +314,32 @@ public class TestClass : IntegrationTest
     async Task M()
     {
         var ext = new ExternalReference();
-        await {|#0:ext.MethodAsync|}();        
+        await {|#0:ext.MethodAsync|}();
+    }
+}
+";
+            const string fixedCode = @"
+public class ExternalReference
+{
+    public Task MethodAsync() => Task.CompletedTask;
+    public Task MethodAsync(CancellationToken c) => Task.CompletedTask;
+}
+
+public class TestClass : IntegrationTest
+{
+    async Task M()
+    {
+        var ext = new ExternalReference();
+        await {|#0:ext.MethodAsync|}(CancellationToken);
     }
 }
 ";
             var result = new DiagnosticResult(Descriptors.Oct2008IntegrationTestForwardCancellationTokenToInvocations()).WithLocation(0);
-            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(), result);
+            await Verify.VerifyCodeFixAsync(container.WithTestingTypes(), result, fixedCode.WithTestingTypes());
         }
 
         [TestCase]
-        public async Task Diagnostic_OverloadForOptionalParameters()
+        public async Task Diagnostic_WithFix_OverloadForOptionalParameters()
         {
             const string container = @"
 public class TestClass : IntegrationTest
@@ -319,37 +351,128 @@ public class TestClass : IntegrationTest
     }
 
     Task MethodAsync(string a, string b = null, Object c = null) => Task.CompletedTask;
-    Task MethodAsync(string a, CancellationToken ct) => Task.CompletedTask;    
+    Task MethodAsync(string a, CancellationToken ct) => Task.CompletedTask;
+    Task MethodAsync(string a, string b, Object c, CancellationToken ct) => Task.CompletedTask;
+}
+";
+            const string fixedCode = @"
+public class TestClass : IntegrationTest
+{
+    async Task M()
+    {
+        await {|#0:MethodAsync|}(""any"", CancellationToken);
+        await {|#1:MethodAsync|}(""any"", ""thing"", ""again"", CancellationToken);
+    }
+
+    Task MethodAsync(string a, string b = null, Object c = null) => Task.CompletedTask;
+    Task MethodAsync(string a, CancellationToken ct) => Task.CompletedTask;
     Task MethodAsync(string a, string b, Object c, CancellationToken ct) => Task.CompletedTask;
 }
 ";
             var result0 = new DiagnosticResult(Descriptors.Oct2008IntegrationTestForwardCancellationTokenToInvocations()).WithLocation(0);
             var result1 = new DiagnosticResult(Descriptors.Oct2008IntegrationTestForwardCancellationTokenToInvocations()).WithLocation(1);
             
-            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(), result0, result1);
+            await Verify.VerifyCodeFixAsync(container.WithTestingTypes(), new []{result0, result1}, fixedCode.WithTestingTypes());
         }
-        
+
         [TestCase]
-        public async Task Diagnostic_UnorderedNamedParameters()
+        public async Task Diagnostic_WithFix_ExternalGenericTypeMethod()
         {
             const string container = @"
+public class AccountResource {}
+public class BasicRepository<TResource> where TResource : class
+{
+    public async Task<TResource> Get(string idOrHref) { throw new NotImplementedException(); } 
+    public async Task<TResource> Get(string idOrHref, CancellationToken cancellationToken) { throw new NotImplementedException(); }
+}
+
 public class TestClass : IntegrationTest
 {
-    async Task M()
+    public async Task M(BasicRepository<AccountResource> repository)
     {
-        await {|#0:MethodAsync|}(z: ""Hello world"", x: 5, y: true);            
+        var accountResource = await {|#0:repository.Get|}(""id""); 
     }
+}
+";
+            const string fixedCode = @"
+public class AccountResource {}
+public class BasicRepository<TResource> where TResource : class
+{
+    public async Task<TResource> Get(string idOrHref) { throw new NotImplementedException(); } 
+    public async Task<TResource> Get(string idOrHref, CancellationToken cancellationToken) { throw new NotImplementedException(); }
+}
 
-    Task MethodAsync(int x, bool y = default, string z = """") => Task.CompletedTask;
-    Task MethodAsync(int x, bool y = default, string z = """", CancellationToken c = default) => Task.CompletedTask;
+public class TestClass : IntegrationTest
+{
+    public async Task M(BasicRepository<AccountResource> repository)
+    {
+        var accountResource = await {|#0:repository.Get|}(""id"", CancellationToken); 
+    }
 }
 ";
             var result = new DiagnosticResult(Descriptors.Oct2008IntegrationTestForwardCancellationTokenToInvocations()).WithLocation(0);
-            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(), result);
+            await Verify.VerifyCodeFixAsync(container.WithTestingTypes(), result, fixedCode.WithTestingTypes());
+        }
+
+        [TestCase]
+        public async Task Diagnostic_WithFix_GenericWhereTypeIsErased()
+        {
+            const string container = @"
+public class Reader
+{
+    public Task<T> Read<T>(int i) => Task.FromResult(default(T));
+    public Task<T> Read<T>(int i, CancellationToken ct = default) => Task.FromResult(default(T));
+}
+
+public class TestClass : IntegrationTest
+{
+    public async Task<int> M(Reader reader)
+    {
+        return await {|#0:reader.Read<int>|}(1); 
+    }
+}
+";
+            const string fixedCode = @"
+public class Reader
+{
+    public Task<T> Read<T>(int i) => Task.FromResult(default(T));
+    public Task<T> Read<T>(int i, CancellationToken ct = default) => Task.FromResult(default(T));
+}
+
+public class TestClass : IntegrationTest
+{
+    public async Task<int> M(Reader reader)
+    {
+        return await {|#0:reader.Read<int>|}(1, CancellationToken); 
+    }
+}
+";
+            var result = new DiagnosticResult(Descriptors.Oct2008IntegrationTestForwardCancellationTokenToInvocations()).WithLocation(0);
+            await Verify.VerifyCodeFixAsync(container.WithTestingTypes(), result, fixedCode.WithTestingTypes());
         }
         
         [TestCase]
-        public async Task Diagnostic_LocalStaticMethod()
+        public async Task Diagnostic_NoFix_StaticMethodBoundary()
+        {
+            // This will be a surprise, as directly passing CancellationToken (from IntegrationTest) is not a valid code (static context).
+            // The intention is to notify user and user should fix by adding CancellationToken parameter on the static method.
+            const string container = @"
+public class TestClass : IntegrationTest
+{
+    public static async Task M()
+    {
+        await {|#0:InnerMethod|}();
+
+        Task InnerMethod(CancellationToken ct = default) => Task.CompletedTask;
+    }
+}
+";
+            var result = new DiagnosticResult(Descriptors.Oct2008IntegrationTestForwardCancellationTokenToInvocations()).WithLocation(0);
+            await Verify.VerifyCodeFixAsync(container.WithTestingTypes(), result, container.WithTestingTypes());
+        }
+
+        [TestCase]
+        public async Task Diagnostic_NoFix_LocalStaticMethod()
         {
             // This will be a surprise, as directly passing CancellationToken (from IntegrationTest) is not a valid code (static context).
             // The intention is to notify user and user should fix by adding CancellationToken parameter on the static method. 
@@ -368,58 +491,7 @@ public class TestClass : IntegrationTest
 }
 ";
             var result = new DiagnosticResult(Descriptors.Oct2008IntegrationTestForwardCancellationTokenToInvocations()).WithLocation(0);
-            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(), result);
-        }
-        
-        [TestCase]
-        public async Task Diagnostic_ExternalGenericTypeMethod()
-        {
-            // This will be a surprise, as directly passing CancellationToken (from IntegrationTest) is not a valid code (static context).
-            // The intention is to notify user and user should fix by adding CancellationToken parameter on the static method. 
-            const string container = @"
-
-public class AccountResource {}
-public class BasicRepository<TResource> where TResource : class
-{
-    public async Task<TResource> Get(string idOrHref) { throw new NotImplementedException(); } 
-    public async Task<TResource> Get(string idOrHref, CancellationToken cancellationToken) { throw new NotImplementedException(); }
-}
-
-public class TestClass : IntegrationTest
-{
-    public async Task M(BasicRepository<AccountResource> repository)
-    {
-        var accountResource = await {|#0:repository.Get|}(""id""); 
-    }
-}
-";
-            var result = new DiagnosticResult(Descriptors.Oct2008IntegrationTestForwardCancellationTokenToInvocations()).WithLocation(0);
-            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(), result);
-        }
-        
-        [TestCase]
-        public async Task Diagnostic_GenericWhereTypeIsErased()
-        {
-            // This will be a surprise, as directly passing CancellationToken (from IntegrationTest) is not a valid code (static context).
-            // The intention is to notify user and user should fix by adding CancellationToken parameter on the static method. 
-            const string container = @"
-
-public class Reader
-{
-    public Task<T> Read<T>(int i) => Task.FromResult(default(T));
-    public Task<T> Read<T>(int i, CancellationToken ct = default) => Task.FromResult(default(T));
-}
-
-public class TestClass : IntegrationTest
-{
-    public async Task<int> M(Reader reader)
-    {
-        return await {|#0:reader.Read<int>|}(1); 
-    }
-}
-";
-            var result = new DiagnosticResult(Descriptors.Oct2008IntegrationTestForwardCancellationTokenToInvocations()).WithLocation(0);
-            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(), result);
+            await Verify.VerifyCodeFixAsync(container.WithTestingTypes(), result, container.WithTestingTypes());
         }
     }
 }

--- a/source/Tests/Tests.csproj
+++ b/source/Tests/Tests.csproj
@@ -13,13 +13,17 @@
 
   <ItemGroup>
 
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.1" />
+
+    <PackageReference Include="Microsoft.CodeAnalysis.Testing.Verifiers.NUnit" Version="1.1.1" />
+
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="nunit" Version="3.13.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.23" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.8.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit" Version="1.0.1-beta1.21064.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.NUnit" Version="1.0.1-beta1.21064.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.NUnit" Version="1.1.1" />
     <PackageReference Include="xunit.core" Version="2.4.1" />
   </ItemGroup>
 

--- a/source/Tests/Tests.csproj
+++ b/source/Tests/Tests.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="nunit" Version="3.13.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.23" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit" Version="1.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.NUnit" Version="1.1.1" />
     <PackageReference Include="xunit.core" Version="2.4.1" />


### PR DESCRIPTION
This is a continuation from the original work on `OCT2008` diagnostic. ([Here](https://github.com/OctopusDeploy/RoslynAnalyzers/pull/15))

This delivery adds the light-bulb hint to fix reported `OCT2008` diagnostic.

# Result 
![Screen Shot 2022-10-03 at 3 18 58 pm](https://user-images.githubusercontent.com/15998611/193500956-1e03de4f-a555-4b93-bc05-ab8ece8d8962.png)

![Screen Shot 2022-10-03 at 3 19 41 pm](https://user-images.githubusercontent.com/15998611/193500990-04880e8d-4589-40e3-8165-b65c1ffcd791.png)
