### PR TITLE
Fix Visual Studio compilation error from Microsoft CodeAnalysis reference

### DIFF
--- a/source/RoslynAnalyzers/RoslynAnalyzers.csproj
+++ b/source/RoslynAnalyzers/RoslynAnalyzers.csproj
@@ -27,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.1" />
   </ItemGroup>
 
 </Project>

--- a/source/RoslynAnalyzers/RoslynAnalyzers.csproj
+++ b/source/RoslynAnalyzers/RoslynAnalyzers.csproj
@@ -27,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
   </ItemGroup>
 
 </Project>

--- a/source/Tests/Tests.csproj
+++ b/source/Tests/Tests.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="nunit" Version="3.13.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.23" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit" Version="1.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.NUnit" Version="1.1.1" />
     <PackageReference Include="xunit.core" Version="2.4.1" />

--- a/source/Tests/Tests.csproj
+++ b/source/Tests/Tests.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="nunit" Version="3.13.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.23" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.3.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.NUnit" Version="1.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.NUnit" Version="1.1.1" />
     <PackageReference Include="xunit.core" Version="2.4.1" />


### PR DESCRIPTION
Referencing `Microsoft.CodeAnalysis.CSharp` version `4.3.0` resulted in compilation error in VisualStudio.

<img width="935" alt="Screen Shot 2022-10-05 at 5 05 29 pm" src="https://user-images.githubusercontent.com/15998611/193992230-132e25fc-6541-4279-9705-7f2df1469387.png">

Issue is resolved by referencing version `4.2.0`