### PR TITLE
Expand the OCT2006 rule allow immutable data in TestContainer classes

### DIFF
--- a/source/RoslynAnalyzers/Descriptors.cs
+++ b/source/RoslynAnalyzers/Descriptors.cs
@@ -61,11 +61,11 @@ namespace Octopus.RoslynAnalyzers
             "added at multiple levels of the class hierarchy in a given file."
         );
 
-        public static DiagnosticDescriptor Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethods => GetTestAnalyzerDescriptor(
+        public static DiagnosticDescriptor Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData => GetTestAnalyzerDescriptor(
             "OCT2006",
-            "Integration test container classes should only contain nested types and methods",
-            "Integration test container classes should only contain integration test classes and methods, any other complex logic or state " +
-            "should be in builders, class/assembly fixtures, or some other generic helper."
+            "Integration test container classes should only contain nested types, methods and immutable data",
+            @"Integration test container classes should only contain integration test classes and methods or immutable data.
+Any other complex logic or state should be in builders, class/assembly fixtures, or some other generic helper."
         );
         
         public static DiagnosticDescriptor Oct2007IntegrationTestContainersMethodsMustBePrivate => GetTestAnalyzerDescriptor(

--- a/source/RoslynAnalyzers/RoslynAnalyzers.csproj
+++ b/source/RoslynAnalyzers/RoslynAnalyzers.csproj
@@ -12,7 +12,7 @@
     <NoWarn>RS2008</NoWarn>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- At the time of writing anything later than netstandard 2.0 doesn't work in Visual Studio -->
+    <!-- As at Feb 2021 anything later than netstandard 2.0 doesn't work in Visual Studio -->
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>Octopus Deploy Roslyn analyzers</Description>

--- a/source/RoslynAnalyzers/Testing/Integration/IntegrationTestContainerAnalyzer.cs
+++ b/source/RoslynAnalyzers/Testing/Integration/IntegrationTestContainerAnalyzer.cs
@@ -34,8 +34,10 @@ namespace Octopus.RoslynAnalyzers.Testing.Integration
                 context.ReportDiagnostic(Diagnostic.Create(Descriptors.Oct2005DoNotNestIntegrationTestContainerClasses, classSymbol.Locations.First()));
             }
 
-            foreach (var symbol in classSymbol.GetMembers().ExceptImplicitlyDeclared())
+            foreach (var symbol in classSymbol.GetMembers())
             {
+                if(symbol.IsImplicitlyDeclared) continue;
+                
                 switch (symbol)
                 {
                     case ITypeSymbol:
@@ -126,7 +128,6 @@ namespace Octopus.RoslynAnalyzers.Testing.Integration
             // we are already enforcing the symbol is readonly, so all ValueTypes are OK
             if (typeSymbol.IsValueType) return true;
 
-            // TODO what about IReadOnlyDictionary
             return typeSymbol.SpecialType switch
             {
                 SpecialType.System_Delegate => true,

--- a/source/RoslynAnalyzers/Testing/Integration/IntegrationTestContainerAnalyzer.cs
+++ b/source/RoslynAnalyzers/Testing/Integration/IntegrationTestContainerAnalyzer.cs
@@ -12,7 +12,7 @@ namespace Octopus.RoslynAnalyzers.Testing.Integration
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
             Descriptors.Oct2004IntegrationTestContainerClassMustBeStatic,
             Descriptors.Oct2005DoNotNestIntegrationTestContainerClasses,
-            Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethods,
+            Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData,
             Descriptors.Oct2007IntegrationTestContainersMethodsMustBePrivate);
 
         internal override void AnalyzeCompilation(INamedTypeSymbol classSymbol, SymbolAnalysisContext context, OctopusTestingContext octopusTestingContext)
@@ -34,27 +34,121 @@ namespace Octopus.RoslynAnalyzers.Testing.Integration
                 context.ReportDiagnostic(Diagnostic.Create(Descriptors.Oct2005DoNotNestIntegrationTestContainerClasses, classSymbol.Locations.First()));
             }
 
-            var memberSymbolsThatAreNotTypeOrMethodDefinitions = classSymbol
-                .GetMembers()
-                .ExceptOfType<ITypeSymbol>()
-                .ExceptOfType<IMethodSymbol>()
-                .ExceptImplicitlyDeclared();
-
-            foreach (var symbol in memberSymbolsThatAreNotTypeOrMethodDefinitions)
+            foreach (var symbol in classSymbol.GetMembers().ExceptImplicitlyDeclared())
             {
-                context.ReportDiagnostic(Diagnostic.Create(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethods, symbol.Locations.First()));
+                switch (symbol)
+                {
+                    case ITypeSymbol:
+                        // nested enums/structs/classes are all OK regardless of public/private/etc
+                        // nested IntegrationTest classes themselves fall under this.
+                        break;
+
+                    case IMethodSymbol methodSymbol:
+                    {
+                        // only private methods are OK; ignoring property setters (they are handled below)
+                        if (methodSymbol.MethodKind is MethodKind.PropertyGet or MethodKind.PropertySet) continue;
+
+                        if (methodSymbol.DeclaredAccessibility != Accessibility.Private)
+                        {
+                            context.ReportDiagnostic(Diagnostic.Create(Descriptors.Oct2007IntegrationTestContainersMethodsMustBePrivate, symbol.Locations.First()));
+                        }
+
+                        break;
+                    }
+
+                    case IFieldSymbol fieldSymbol:
+                    {
+                        if (fieldSymbol.DeclaredAccessibility != Accessibility.Private)
+                        {
+                            // fields must be private
+                            context.ReportDiagnostic(Diagnostic.Create(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData, symbol.Locations.First()));
+                        }
+
+                        if (fieldSymbol.IsConst)
+                        {
+                            // const is OK; the compiler won't let us put anything mutable in a const field so we don't have to check
+                            break;
+                        }
+
+                        if (fieldSymbol.IsReadOnly)
+                        {
+                            // readonly is only OK if it holds a type that is known to be immutable 
+                            if (!IsKnownImmutableType(context, fieldSymbol.Type))
+                            {
+                                context.ReportDiagnostic(Diagnostic.Create(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData, symbol.Locations.First()));
+                            }
+                        }
+                        else
+                        {
+                            // if it's not readonly or const, then it's definitely not OK
+                            context.ReportDiagnostic(Diagnostic.Create(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData, symbol.Locations.First()));
+                        }
+
+                        break;
+                    }
+
+                    case IPropertySymbol propertySymbol:
+                    {
+                        if (propertySymbol.DeclaredAccessibility != Accessibility.Private)
+                        {
+                            // fields must be private
+                            context.ReportDiagnostic(Diagnostic.Create(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData, symbol.Locations.First()));
+                        }
+
+                        if (propertySymbol.IsReadOnly)
+                        {
+                            // readonly is only OK if it holds a type that is known to be immutable 
+                            if (!IsKnownImmutableType(context, propertySymbol.Type))
+                            {
+                                context.ReportDiagnostic(Diagnostic.Create(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData, symbol.Locations.First()));
+                            }
+                        }
+                        else
+                        {
+                            // if it's not readonly or const, then it's definitely not OK
+                            context.ReportDiagnostic(Diagnostic.Create(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData, symbol.Locations.First()));
+                        }
+
+                        break;
+                    }
+
+                    default:
+                        // other than types, properties and fields, what else can we put in a class?
+                        // whatever it is, report it (this is what the previous version of the analyzer did so we maintain compatibility)
+                        context.ReportDiagnostic(Diagnostic.Create(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData, symbol.Locations.First()));
+                        break;
+                }
             }
+        }
 
-            var methodsOnClassThatAreNotPrivate = classSymbol
-                .GetAllMembersOfType<IMethodSymbol>()
-                .ExceptImplicitlyDeclared()
-                .ExceptPropertyAccessors()
-                .Where(m => m.DeclaredAccessibility != Accessibility.Private);
+        static bool IsKnownImmutableType(SymbolAnalysisContext context, ITypeSymbol typeSymbol)
+        {
+            // we are already enforcing the symbol is readonly, so all ValueTypes are OK
+            if (typeSymbol.IsValueType) return true;
 
-            foreach (var symbol in methodsOnClassThatAreNotPrivate)
+            // TODO what about IReadOnlyDictionary
+            return typeSymbol.SpecialType switch
             {
-                context.ReportDiagnostic(Diagnostic.Create(Descriptors.Oct2007IntegrationTestContainersMethodsMustBePrivate, symbol.Locations.First()));
-            }
+                SpecialType.System_Delegate => true,
+                SpecialType.System_String => true,
+                SpecialType.System_Collections_IEnumerable => true, // IEnumerable exactly is OK; subtypes are not neccessarily
+                
+                // link from IEnumerable<string> => IEnumerable<> so we can compare
+                SpecialType.None => typeSymbol is INamedTypeSymbol { IsGenericType: true } namedTypeSymbol && namedTypeSymbol.OriginalDefinition.SpecialType switch
+                {
+                    SpecialType.System_Collections_Generic_IEnumerable_T => true,
+                    SpecialType.System_Collections_Generic_IReadOnlyList_T => true,
+                    SpecialType.System_Collections_Generic_IReadOnlyCollection_T => true,
+                    SpecialType.None => namedTypeSymbol.OriginalDefinition.Name switch
+                    {
+                        "IReadOnlySet" => true,
+                        "IReadOnlyDictionary" => true,
+                        _ => false
+                    },
+                    _ => false
+                },
+                _ => false  
+            };
         }
     }
 }

--- a/source/RoslynAnalyzers/Testing/Integration/IntegrationTestContainerAnalyzer.cs
+++ b/source/RoslynAnalyzers/Testing/Integration/IntegrationTestContainerAnalyzer.cs
@@ -64,6 +64,7 @@ namespace Octopus.RoslynAnalyzers.Testing.Integration
                         {
                             // fields must be private
                             context.ReportDiagnostic(Diagnostic.Create(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData, symbol.Locations.First()));
+                            break;
                         }
 
                         if (fieldSymbol.IsConst)
@@ -95,6 +96,7 @@ namespace Octopus.RoslynAnalyzers.Testing.Integration
                         {
                             // fields must be private
                             context.ReportDiagnostic(Diagnostic.Create(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData, symbol.Locations.First()));
+                            break;
                         }
 
                         if (propertySymbol.IsReadOnly)
@@ -142,7 +144,7 @@ namespace Octopus.RoslynAnalyzers.Testing.Integration
                     SpecialType.System_Collections_Generic_IReadOnlyCollection_T => true,
                     SpecialType.None => namedTypeSymbol.OriginalDefinition.Name switch
                     {
-                        "IReadOnlySet" => true,
+                        "IReadOnlySet" => true, // I couldn't find an elegant way to get the fully namespaced version of these, and it wouldn't really matter anyway
                         "IReadOnlyDictionary" => true,
                         _ => false
                     },

--- a/source/Tests/Testing/Integration/IntegrationTestContainerAnalyzerFixture.cs
+++ b/source/Tests/Testing/Integration/IntegrationTestContainerAnalyzerFixture.cs
@@ -201,19 +201,24 @@ public static class ContainerOne
         }
 
         [TestCase]
-        public async Task DetectsIntegrationTestContainerClassesWithMembersThatAreNotTypesOrPrivateMethods()
+        public async Task IntegrationTestContainerClassMembers_ConstsAllowed()
         {
             var container = @"
-using System.Collections.Generic;
-
 public static class Container
 {
-    // ----- Constants are OK -----
-
     const string SomeConstantString = ""foo"";
 
-    // ----- Fields are only OK if they are readonly and hold a type which is known to be immutable -----
-
+    public class SomeIntegrationTest : IntegrationTest { } // always need this to trigger container-class logic
+}";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+        
+        [TestCase]
+        public async Task IntegrationTestContainerClassMembers_FieldsOkIfReadOnlyAndImmutable()
+        {
+            var container = @"
+public static class Container
+{
     static readonly string SomeReadOnlyString = ""foo"";
 
     // readonly ValueTypes are all OK
@@ -230,8 +235,20 @@ public static class Container
     // public = not ok
     public static readonly string {|#2:SomePublicReadOnlyString|} = ""foo"";
 
-    // ----- Properties are only OK if they are readonly and hold a type which is known to be immutable -----
-
+    public class SomeIntegrationTest : IntegrationTest { } // always need this to trigger container-class logic
+}";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(),
+                new DiagnosticResult(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData).WithLocation(0),
+                new DiagnosticResult(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData).WithLocation(1),
+                new DiagnosticResult(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData).WithLocation(2));
+        }
+        
+        [TestCase]
+        public async Task IntegrationTestContainerClassMembers_PropertiesOkIfReadOnlyAndImmutable()
+        {
+            var container = @"
+public static class Container
+{
     static string SomeReadOnlyProp { get; } = ""foo"";
 
     // readonly ValueTypes are all OK
@@ -240,71 +257,114 @@ public static class Container
     static DateTimeKind SomeReadOnlyDateTimeKindProp => DateTimeKind.Utc;
 
     // readonly reference types are not OK except for special cases like IEnumerable, IReadOnlyCollection; tested below
-    static Random {|#3:SomeReadOnlyRandomProp|} { get; } = new(); // bad; System.Random is not known to be immutable, probably unsafe to share
+    static Random {|#0:SomeReadOnlyRandomProp|} { get; } = new(); // bad; System.Random is not known to be immutable, probably unsafe to share
 
     // not readonly = not ok
-    static string {|#4:SomeMutableStringProp|} {get;set;} = ""foo""; // bad; not readonly
+    static string {|#1:SomeMutableStringProp|} {get;set;} = ""foo""; // bad; not readonly
 
     // public = not ok
-    public static string {|#5:SomePublicReadOnlyStringProp|} {get;} = ""foo"";
+    public static string {|#2:SomePublicReadOnlyStringProp|} {get;} = ""foo"";
 
-    // ----- Methods are only OK if they are nonpublic -----
-
-    public static void {|#99:SomePublicMethod|}()  { }
+    public class SomeIntegrationTest : IntegrationTest { } // always need this to trigger container-class logic
+}";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(),
+                new DiagnosticResult(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData).WithLocation(0),
+                new DiagnosticResult(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData).WithLocation(1),
+                new DiagnosticResult(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData).WithLocation(2));
+        }
+        
+        [TestCase]
+        public async Task IntegrationTestContainerClassMembers_MethodsOkIfNonPublic()
+        {
+            var container = @"
+public static class Container
+{
+    public static void {|#0:SomePublicMethod|}()  { }
 
     static void SomePrivateMethod() { }
 
-    // ----- Nested types are all OK -----
-
-    public class SomeIntegrationTest : IntegrationTest  // good, class is an integration test
-    { }
-
+    public class SomeIntegrationTest : IntegrationTest { } // always need this to trigger container-class logic
+}";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(),
+                new DiagnosticResult(Descriptors.Oct2007IntegrationTestContainersMethodsMustBePrivate).WithLocation(0));
+        }
+        
+        [TestCase]
+        public async Task IntegrationTestContainerClassMembers_NestedTypesOk()
+        {
+            var container = @"
+public static class Container
+{
     class SomeClass{ }
 
     struct SomeStruct{ }
 
     enum SomeEnum{ }
 
-    // ----- fields holding collections -----
-
+    public class SomeIntegrationTest : IntegrationTest { } // always need this to trigger container-class logic
+}";
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes());
+        }
+        
+        [TestCase]
+        public async Task IntegrationTestContainerClassMembers_FieldsHoldingCollectionsOkIfTypeIsImmutable()
+        {
+            var container = @"
+using System.Collections.Generic;
+public static class Container
+{
     static readonly IEnumerable<string> SomeReadonlyEnumerableOfString = new[]{ ""foo"", ""bar"" };  // good, property is immutable and nonpublic
     static readonly IReadOnlyList<string> SomeReadOnlyListOfString = new[]{ ""foo"", ""bar"" };  // good, property is immutable and nonpublic
     static readonly IReadOnlyDictionary<int, string> SomeReadOnlyDict = new Dictionary<int, string>(){ [0] = ""foo"", [1] = ""bar"" };  // good, property is immutable and nonpublic
     // static readonly IReadOnlySet<string> SomeReadOnlySet = new HashSet<string>(){ ""foo"", ""bar"" };  // good, property is immutable and nonpublic. COMMENTED: SEE NOTE
     
-    static IEnumerable<string> {|#30:SomeMutableEnumerableOfString|} = new[]{ ""foo"", ""bar"" };  // bad, property is mutable
+    static IEnumerable<string> {|#0:SomeMutableEnumerableOfString|} = new[]{ ""foo"", ""bar"" };  // bad, property is mutable
 
-    static readonly string[] {|#31:SomeArrayOfString|} = new[]{ ""foo"", ""bar"" };  // bad, property is readonly but array itself is mutable
-    static readonly List<string> {|#32:SomeListOfString|} = new(){ ""foo"", ""bar"" };  // bad, property is readonly but list itself is mutable
-    static readonly Dictionary<int, string> {|#33:SomeMutableDictionary|} = new Dictionary<int, string>(){ [0] = ""foo"", [1] = ""bar"" }; // bad, property is readonly but list itself is mutable
-    static readonly HashSet<string> {|#34:SomeMutableSet|} = new HashSet<string>(){ ""foo"", ""bar"" }; // bad, property is readonly but list itself is mutable
+    static readonly string[] {|#1:SomeArrayOfString|} = new[]{ ""foo"", ""bar"" };  // bad, property is readonly but array itself is mutable
+    static readonly List<string> {|#2:SomeListOfString|} = new(){ ""foo"", ""bar"" };  // bad, property is readonly but list itself is mutable
+    static readonly Dictionary<int, string> {|#3:SomeMutableDictionary|} = new Dictionary<int, string>(){ [0] = ""foo"", [1] = ""bar"" }; // bad, property is readonly but list itself is mutable
+    static readonly HashSet<string> {|#4:SomeMutableSet|} = new HashSet<string>(){ ""foo"", ""bar"" }; // bad, property is readonly but list itself is mutable
 
-    // properties holding collections not explicitly tested because it's the same logic as fields
-}
-";
+    public class SomeIntegrationTest : IntegrationTest { } // always need this to trigger container-class logic
+}";
             // IReadOnlySet Note: Our DLL targets netstandard2.0, with the comment "As at Feb 2021 anything later than netstandard 2.0 doesn't work in Visual Studio".
             // IReadOnlySet was added in .NET 5 so isn't in netstandard2.0, so, while it works in the real world, we can't hit it with unit tests
-            var oct2006 = Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData;
-            var oct2007 = Descriptors.Oct2007IntegrationTestContainersMethodsMustBePrivate;
-
-            var source = container.WithTestingTypes();
-            Console.WriteLine(source); // to help with debugging
             
-            await Verify.VerifyAnalyzerAsync(source,
-                new DiagnosticResult(oct2006).WithLocation(0),
-                new DiagnosticResult(oct2006).WithLocation(1),
-                new DiagnosticResult(oct2006).WithLocation(2),
-                new DiagnosticResult(oct2006).WithLocation(3),
-                new DiagnosticResult(oct2006).WithLocation(4),
-                new DiagnosticResult(oct2006).WithLocation(5),
-                
-                new DiagnosticResult(oct2006).WithLocation(30),
-                new DiagnosticResult(oct2006).WithLocation(31),
-                new DiagnosticResult(oct2006).WithLocation(32),
-                new DiagnosticResult(oct2006).WithLocation(33),
-                new DiagnosticResult(oct2006).WithLocation(34),
-                
-                new DiagnosticResult(oct2007).WithLocation(99));
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(),
+                new DiagnosticResult(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData).WithLocation(0),
+                new DiagnosticResult(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData).WithLocation(1),
+                new DiagnosticResult(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData).WithLocation(2),
+                new DiagnosticResult(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData).WithLocation(3),
+                new DiagnosticResult(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData).WithLocation(4));
+        }
+        
+        [TestCase]
+        public async Task IntegrationTestContainerClassMembers_PropertiesHoldingCollectionsOkIfTypeIsImmutable()
+        {
+            var container = @"
+using System.Collections.Generic;
+public static class Container
+{
+    static IEnumerable<string> SomeReadonlyEnumerableOfString {get;} = new[]{ ""foo"", ""bar"" };  // good, property is immutable and nonpublic
+    static IReadOnlyList<string> SomeReadOnlyListOfString {get;} = new[]{ ""foo"", ""bar"" };  // good, property is immutable and nonpublic
+    static IReadOnlyDictionary<int, string> SomeReadOnlyDict {get;} = new Dictionary<int, string>(){ [0] = ""foo"", [1] = ""bar"" };  // good, property is immutable and nonpublic
+    // static IReadOnlySet<string> SomeReadOnlySet {get;} = new HashSet<string>(){ ""foo"", ""bar"" };  // good, property is immutable and nonpublic. COMMENTED: SEE NOTE
+   
+    static string[] {|#0:SomeArrayOfString|} {get;} = new[]{ ""foo"", ""bar"" };  // bad, property is readonly but array itself is mutable
+    static List<string> {|#1:SomeListOfString|} {get;} = new(){ ""foo"", ""bar"" };  // bad, property is readonly but list itself is mutable
+    static Dictionary<int, string> {|#2:SomeMutableDictionary|} {get;} = new Dictionary<int, string>(){ [0] = ""foo"", [1] = ""bar"" }; // bad, property is readonly but list itself is mutable
+    static HashSet<string> {|#3:SomeMutableSet|} {get;} = new HashSet<string>(){ ""foo"", ""bar"" }; // bad, property is readonly but list itself is mutable
+
+    public class SomeIntegrationTest : IntegrationTest { } // always need this to trigger container-class logic
+}";
+            // IReadOnlySet Note: Our DLL targets netstandard2.0, with the comment "As at Feb 2021 anything later than netstandard 2.0 doesn't work in Visual Studio".
+            // IReadOnlySet was added in .NET 5 so isn't in netstandard2.0, so, while it works in the real world, we can't hit it with unit tests
+            
+            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(),
+                new DiagnosticResult(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData).WithLocation(0),
+                new DiagnosticResult(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData).WithLocation(1),
+                new DiagnosticResult(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData).WithLocation(2),
+                new DiagnosticResult(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData).WithLocation(3));
         }
     }
 }

--- a/source/Tests/Testing/Integration/IntegrationTestContainerAnalyzerFixture.cs
+++ b/source/Tests/Testing/Integration/IntegrationTestContainerAnalyzerFixture.cs
@@ -204,28 +204,107 @@ public static class ContainerOne
         public async Task DetectsIntegrationTestContainerClassesWithMembersThatAreNotTypesOrPrivateMethods()
         {
             var container = @"
+using System.Collections.Generic;
+
 public static class Container
 {
-    public static string {|#0:Property|} { get; set; }
-    static string {|#1:field|};
+    // ----- Constants are OK -----
 
-    public static void {|#2:PublicMethod|}()
-    {
-    }
+    const string SomeConstantString = ""foo"";
 
-    static void PrivateMethod()
-    {
-    }
+    // ----- Fields are only OK if they are readonly and hold a type which is known to be immutable -----
 
-    public class TestOne : IntegrationTest
-    {
-    }
+    static readonly string SomeReadOnlyString = ""foo"";
+
+    // readonly ValueTypes are all OK
+    static readonly int SomeReadOnlyInt = 1;
+    static readonly DateTime SomeReadOnlyDateTime = DateTime.UtcNow;
+    static readonly DateTimeKind SomeReadOnlyDateTimeKind = DateTimeKind.Utc;
+
+    // readonly reference types are not OK except for special cases like IEnumerable, IReadOnlyCollection; tested below
+    static readonly Random {|#0:SomeReadOnlyRandom|} = new(); // bad; System.Random is not known to be immutable, probably unsafe to share
+
+    // not readonly = not ok
+    static string {|#1:someMutableString|} = ""foo""; // bad; not readonly
+
+    // public = not ok
+    public static readonly string {|#2:SomePublicReadOnlyString|} = ""foo"";
+
+    // ----- Properties are only OK if they are readonly and hold a type which is known to be immutable -----
+
+    static string SomeReadOnlyProp { get; } = ""foo"";
+
+    // readonly ValueTypes are all OK
+    static int SomeReadOnlyIntProp => 1;
+    static DateTime SomeReadOnlyDateTimeProp => DateTime.UtcNow;
+    static DateTimeKind SomeReadOnlyDateTimeKindProp => DateTimeKind.Utc;
+
+    // readonly reference types are not OK except for special cases like IEnumerable, IReadOnlyCollection; tested below
+    static Random {|#3:SomeReadOnlyRandomProp|} { get; } = new(); // bad; System.Random is not known to be immutable, probably unsafe to share
+
+    // not readonly = not ok
+    static string {|#4:SomeMutableStringProp|} {get;set;} = ""foo""; // bad; not readonly
+
+    // public = not ok
+    public static string {|#5:SomePublicReadOnlyStringProp|} {get;} = ""foo"";
+
+    // ----- Methods are only OK if they are nonpublic -----
+
+    public static void {|#99:SomePublicMethod|}()  { }
+
+    static void SomePrivateMethod() { }
+
+    // ----- Nested types are all OK -----
+
+    public class SomeIntegrationTest : IntegrationTest  // good, class is an integration test
+    { }
+
+    class SomeClass{ }
+
+    struct SomeStruct{ }
+
+    enum SomeEnum{ }
+
+    // ----- fields holding collections -----
+
+    static readonly IEnumerable<string> SomeReadonlyEnumerableOfString = new[]{ ""foo"", ""bar"" };  // good, property is immutable and nonpublic
+    static readonly IReadOnlyList<string> SomeReadOnlyListOfString = new[]{ ""foo"", ""bar"" };  // good, property is immutable and nonpublic
+    static readonly IReadOnlyDictionary<int, string> SomeReadOnlyDict = new Dictionary<int, string>(){ [0] = ""foo"", [1] = ""bar"" };  // good, property is immutable and nonpublic
+    // static readonly IReadOnlySet<string> SomeReadOnlySet = new HashSet<string>(){ ""foo"", ""bar"" };  // good, property is immutable and nonpublic. COMMENTED: SEE NOTE
+    
+    static IEnumerable<string> {|#30:SomeMutableEnumerableOfString|} = new[]{ ""foo"", ""bar"" };  // bad, property is mutable
+
+    static readonly string[] {|#31:SomeArrayOfString|} = new[]{ ""foo"", ""bar"" };  // bad, property is readonly but array itself is mutable
+    static readonly List<string> {|#32:SomeListOfString|} = new(){ ""foo"", ""bar"" };  // bad, property is readonly but list itself is mutable
+    static readonly Dictionary<int, string> {|#33:SomeMutableDictionary|} = new Dictionary<int, string>(){ [0] = ""foo"", [1] = ""bar"" }; // bad, property is readonly but list itself is mutable
+    static readonly HashSet<string> {|#34:SomeMutableSet|} = new HashSet<string>(){ ""foo"", ""bar"" }; // bad, property is readonly but list itself is mutable
+
+    // properties holding collections not explicitly tested because it's the same logic as fields
 }
 ";
-            var propertyResult = new DiagnosticResult(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethods).WithLocation(0);
-            var fieldResult = new DiagnosticResult(Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethods).WithLocation(1);
-            var methodResult = new DiagnosticResult(Descriptors.Oct2007IntegrationTestContainersMethodsMustBePrivate).WithLocation(2);
-            await Verify.VerifyAnalyzerAsync(container.WithTestingTypes(), propertyResult, fieldResult, methodResult);
+            // IReadOnlySet Note: Our DLL targets netstandard2.0, with the comment "As at Feb 2021 anything later than netstandard 2.0 doesn't work in Visual Studio".
+            // IReadOnlySet was added in .NET 5 so isn't in netstandard2.0, so, while it works in the real world, we can't hit it with unit tests
+            var oct2006 = Descriptors.Oct2006IntegrationTestContainersMustOnlyContainTypesAndMethodsAndImmutableData;
+            var oct2007 = Descriptors.Oct2007IntegrationTestContainersMethodsMustBePrivate;
+
+            var source = container.WithTestingTypes();
+            Console.WriteLine(source); // to help with debugging
+            
+            await Verify.VerifyAnalyzerAsync(source,
+                new DiagnosticResult(oct2006).WithLocation(0),
+                new DiagnosticResult(oct2006).WithLocation(1),
+                new DiagnosticResult(oct2006).WithLocation(2),
+                new DiagnosticResult(oct2006).WithLocation(3),
+                new DiagnosticResult(oct2006).WithLocation(4),
+                new DiagnosticResult(oct2006).WithLocation(5),
+                
+                new DiagnosticResult(oct2006).WithLocation(30),
+                new DiagnosticResult(oct2006).WithLocation(31),
+                new DiagnosticResult(oct2006).WithLocation(32),
+                new DiagnosticResult(oct2006).WithLocation(33),
+                new DiagnosticResult(oct2006).WithLocation(34),
+                
+                new DiagnosticResult(oct2007).WithLocation(99));
         }
     }
 }


### PR DESCRIPTION
## Background

This was discussed a while ago during the nancy project. I wanted to put simple things like constant strings into the IntegrationTest Container class, so I could easily share them across tests.

I raised the idea with @andrewabest, who said it seemed like a reasonable idea and that he was happy with adding static readonly arrays and dictionaries as well

https://octopusdeploy.slack.com/archives/C03SMG7V1CG/p1666124571745079?thread_ts=1666121893.313679&cid=C03SMG7V1CG

## Change

This expands the logic in the analyzer to allow fields and properties which hold data, with the restriction that said data should be immutable.

For example (from the unit test)

```csharp
// good: consts are fine
const string SomeSharedString = "abc";

// good: field is readonly and type is known to be immutable:
static readonly string SomeSharedKey = Convert.FromBase64String("...");

// good: field is readonly and type is known to be immutable:
static readonly IReadOnlyDictionary<int, string> SomeReadOnlyDict = new Dictionary<int, string>(){ [0] = ""foo"", [1] = ""bar"" };  

// bad, property is immutable but type allows mutation.
static readonly Dictionary<int, string> SomeDict = new Dictionary<int, string>(){ [0] = ""foo"", [1] = ""bar"" };  
```

### Discussion

This is not bulletproof; by allowing collection types we let people make a `ReadOnlyList` of some mutable class type, that could go wrong. This seems like a reasonable tradeoff; The cost of checking for recursive immutability would be very high and if a dev really wanted to do that they would just put their mutable collection in some other class anyway

## How to review this PR:

I'm still learning my way around Roslyn, and this is largely based on the existing design. 
E.g: the existing thing was using `RegisterSymbolAction`; I could have changed it to `SyntaxAction` but that felt a bit dangerous.

If I have inadvertently done something the wrong way or fallen into a performance trap, please call it out

Thanks!