### PR TITLE
Enhance oct3008 to allow non-null optional values if they have initializers

### DIFF
--- a/source/RoslynAnalyzers/Descriptors.cs
+++ b/source/RoslynAnalyzers/Descriptors.cs
@@ -147,21 +147,15 @@ Any other complex logic or state should be in builders, class/assembly fixtures,
             DiagnosticSeverity.Error,
             true);
 
-        public static readonly DiagnosticDescriptor OptionalPropertiesOnMessageTypesMustBeNullable = new(
+        public static readonly DiagnosticDescriptor OptionalPropertiesOnMessageTypesMustBeInitializedOrNullable = new(
             "OCT3008",
-            "Optional Properties on MessageTypes must be nullable",
-            "Property \"{0}\" should be of type {1}? (Optional Properties on MessageTypes must be nullable)",
+            "Optional Properties on MessageTypes must be nullable or have initializers",
+            "Property \"{0}\" should have initializer or be of type {1}? (Optional Properties on MessageTypes must be initialized or nullable)",
             Category,
             DiagnosticSeverity.Error,
             true);
 
-        public static readonly DiagnosticDescriptor MessageTypesMustInstantiateCollections = new(
-            "OCT3009",
-            "MessageTypes must instantiate non-nullable collections",
-            "MessageTypes must instantiate non-nullable collections.",
-            Category,
-            DiagnosticSeverity.Error,
-            true);
+        // OCT3009 was "MessageTypes must instantiate non-nullable collections", but this is now subsumed by our "null or initialized" convention. The ID is free for something else to use
 
         public static readonly DiagnosticDescriptor PropertiesOnMessageTypesMustHaveAtLeastOneValidationAttribute = new(
             "OCT3010",

--- a/source/RoslynAnalyzers/Descriptors.cs
+++ b/source/RoslynAnalyzers/Descriptors.cs
@@ -155,7 +155,14 @@ Any other complex logic or state should be in builders, class/assembly fixtures,
             DiagnosticSeverity.Error,
             true);
 
-        // OCT3009 was "MessageTypes must instantiate non-nullable collections", but this is now subsumed by our "null or initialized" convention. The ID is free for something else to use
+        [Obsolete("Removed; The case is now covered by the more general OptionalPropertiesOnMessageTypesMustBeInitializedOrNullable diagnostic")]
+        static readonly DiagnosticDescriptor MessageTypesMustInstantiateCollections = new(
+            "OCT3009",
+            "MessageTypes must instantiate non-nullable collections",
+            "MessageTypes must instantiate non-nullable collections.",
+            Category,
+            DiagnosticSeverity.Hidden,
+            true);
 
         public static readonly DiagnosticDescriptor PropertiesOnMessageTypesMustHaveAtLeastOneValidationAttribute = new(
             "OCT3010",
@@ -173,8 +180,14 @@ Any other complex logic or state should be in builders, class/assembly fixtures,
             DiagnosticSeverity.Error,
             true);
 
-        // note: OCT3012 was "Id Properties on Message Types should be CaseInsensitiveStringTinyTypes", but we determined
-        // that wasn't a good fit for an analyzer as we didn't want to enforce it so strictly. The number is free for some future use.
+        [Obsolete("Removed; We determined that this wasn't a good fit for an analyzer as we didn't want to enforce it so strictly")]
+        static readonly DiagnosticDescriptor IdPropertiesOnMessageTypesMustBeACaseInsensitiveStringTinyType = new(
+            "OCT3012",
+            "Id Properties on Message Types should be CaseInsensitiveStringTinyTypes",
+            "Id Properties on Message Types should be CaseInsensitiveStringTinyTypes",
+            Category,
+            DiagnosticSeverity.Hidden,
+            true);
         
         public static readonly DiagnosticDescriptor MessageTypesMustHaveXmlDocComments = new(
             "OCT3013",

--- a/source/Tests/MessageContractAnalyzerFixture.cs
+++ b/source/Tests/MessageContractAnalyzerFixture.cs
@@ -290,6 +290,8 @@ namespace Octopus.Core.Features.ServerTasks.MessageContracts
             RequiredIntProperty = requiredInt;
             RequiredBoolProperty = requiredBool;
             RequiredCollectionProperty = requiredCollection;
+
+            IntProperty = 27; // We don't decompile the constructor, it must be an inline initializer so this doesn't count
         }
 
         // --- sanity check required properties aren't affected -----
@@ -324,7 +326,7 @@ namespace Octopus.Core.Features.ServerTasks.MessageContracts
         public string InitializedStringPropertyExplicitNull { get; set; } = null!; // OK; If you really want to break things, then you can.
 
         [Optional]
-        public int {|#1:IntProperty|} { get; set; } // NOT OK, must be nullable or initialized
+        public int {|#1:IntProperty|} { get; set; } // NOT OK, must be nullable or initialized.
 
         [Optional]
         public int? NullableIntProperty { get; set; } // OK

--- a/source/Tests/MessageContractAnalyzerFixture.cs
+++ b/source/Tests/MessageContractAnalyzerFixture.cs
@@ -335,7 +335,7 @@ namespace Octopus.Core.Features.ServerTasks.MessageContracts
         public int InitializedIntProperty { get; set; } = 10; // OK
 
         [Optional]
-        public int InitializedIntPropertyEmpty { get; set; } = 0; // OK
+        public int InitializedIntPropertyDefault { get; set; } = 0; // OK
 
         [Optional]
         public bool {|#2:BoolProperty|} { get; set; } // NOT OK, must be nullable or initialized
@@ -347,7 +347,7 @@ namespace Octopus.Core.Features.ServerTasks.MessageContracts
         public bool InitializedBoolProperty { get; set; } = true; // OK
 
         [Optional]
-        public bool InitializedBoolPropertyEmpty { get; set; } = false; // OK
+        public bool InitializedBoolPropertyDefault { get; set; } = false; // OK
 
         [Optional]
         public string[] {|#3:CollectionProperty|} { get; set; } // NOT OK, must be nullable or initialized


### PR DESCRIPTION
## Background

Current State: ❌ means that the analyzer/convention test will report an error. 

```csharp
public class FooRequest : IRequest<FooRequest, FooResponse>
{
    [Optional]
    public int SortOrder { get; set; } // ❌. Compiler will set 0 if the client doesn't supply it, but is that valid?
    
    [Optional]
    public SomeEnumType SomeEnumProp { get; set; } // ❌. Compiler will set the enum's zero case if the client doesn't supply it, but is that valid?
    
    [Optional]
    public string Name { get; set; } // ❌. Compiler will set null if the client doesn't supply it, which violates null reference-type rules.
    
    [Optional]
    public int? SortOrder { get; set; } // ✅, it's nullable
    
    [Optional]
    public int SortOrder { get; set; } = 0; // ❌, our convention didn't understand this
    
    [Optional]
    public bool Confirm { get; set; } // ✅ special case for bools
    
    [Optional]
    public bool? Confirm { get; set; } // ✅ also fine if you want a tri-state
    
    [Optional]
    public List<string> SomeList { get; set; } // ❌, there was a separate convention that collectionTypes should be initialized.

    [Optional]
    public List<string> SomeList { get; set; } = new(); // ✅, special collectionTypes convention checks for this

    [Optional]
    public List<string>? SomeList { get; set; } // ❌, collection types should be initialized. Nobody ever does this so it wasn't really an issue
}
```

If SortOrder is not `int?` then a convention test/analyzer complains at you that optional properties must be nullable.
We allowed a a special case for Optional bools, because enforcing `bool?` everywhere was annoying.

Earlier, the topic of whether MessageContracts were allowed to have default values for optional parameters was discussed at length, culminating in a Zoom call where @andrewabest made the call that yes they were OK.

Allowing use of property initializers lets us remove both the special case for bools, and the collectiontype initialization check.
This PR changes to rules to be as follows

```csharp
public class FooRequest : IRequest<FooRequest, FooResponse>
{
    [Optional]
    public int SortOrder { get; set; }; // ❌. As above, not allowed because we can't say if the compiler default zero is valid here
    
    [Optional]
    public int? SortOrder { get; set; } // ✅, it's nullable
    
    [Optional]
    public int SortOrder { get; set; } = 0; // ✅, now OK, the value has a default of 0

    // Note: examples for Enum, String, etc omitted as they are all identical to the 'int' behaviour
    
    [Optional]
    public bool Confirm { get; set; } // ❌ no more special snowflake for bools
    
    [Optional]
    public bool Confirm { get; set; } = false; // ✅ bools now follow the same pattern as everyone else
    
    [Optional]
    public bool? Confirm { get; set; } // ✅ also fine if you want a tri-state
    
    [Optional]
    public List<string> SomeList { get; set; } // ❌, same outcome but now caught by the default rule rather than special collectiontype rule
    
    [Optional]
    public List<string> SomeList { get; set; } = new(); // ✅, same outcome but now caught by the default rule rather than special collectiontype rule
    
    [Optional]
    public List<string>? SomeList { get; set; } // ✅, This is now ok but as above nobody ever does this so it wasn't really an issue
}
```

Note: While using a constructor to set an initial value is logically the same as a prop initializer, the analyzer doesn't allow it.

```csharp
public class FooRequest : IRequest<FooRequest, FooResponse>
{
   public FooRequest()
   {
      SortOrder = 10;
   }

    [Optional]
    public int SortOrder { get; set; }; // ❌ initialization via constructor doesn't count
}
```

This is intentional; we want to only allow defaults for simple values, rather than more complex stuff that would warrant constructor logic, and also it's much easier to read if you force defaults to be inline