### PR TITLE
Add VoidMethodsMustNotBeAsync and MethodsReturningTaskMustBeAsync

### DIFF
--- a/source/RoslynAnalyzers/AsyncAnalyzer.cs
+++ b/source/RoslynAnalyzers/AsyncAnalyzer.cs
@@ -52,6 +52,11 @@ public class AsyncAnalyzer : DiagnosticAnalyzer
             if (baseTypeList != null && baseTypeList.Any(b => b is IdentifierNameSyntax { Identifier.Text: "IAsyncApiAction" })) return;
         }
         
+        // exemption for things in Octopus.Server.Extensibility. Note that the reflection based test does this by seeing if the Assembly Name
+        // has Octopus.Server.Extensibility somewhere in it. We can't do that so easily; use namespace as an approximation (it wasn't exact anyway)
+
+        if (declaringType != null && declaringType.GetNamespace().Contains("Octopus.Server.Extensibility")) return;
+        
         context.ReportDiagnostic(Diagnostic.Create(MethodsReturningTaskMustBeAsync, methodDec.Identifier.GetLocation()));
     }
 }

--- a/source/RoslynAnalyzers/AsyncAnalyzer.cs
+++ b/source/RoslynAnalyzers/AsyncAnalyzer.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Octopus.RoslynAnalyzers;
+
+using static Octopus.RoslynAnalyzers.Descriptors;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class AsyncAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+        MethodsReturningTaskMustBeAsync);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        
+        if(!Debugger.IsAttached) context.EnableConcurrentExecution();
+        
+        context.RegisterSyntaxNodeAction(CheckNode, SyntaxKind.MethodDeclaration);
+    }
+
+    void CheckNode(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not MethodDeclarationSyntax methodDec) return;
+
+        if (methodDec.ReturnType is not SimpleNameSyntax { Identifier.Text: "Task" or "ValueTask" })
+        {
+            // if it doesn't return Task or ValueTask then we don't care about it
+            return;
+        }
+
+        // don't flag things that are async (that's good!) or abstract methods.
+        if (methodDec.Modifiers.Any(SyntaxKind.AsyncKeyword) || methodDec.Modifiers.Any(SyntaxKind.AbstractKeyword)) return;
+            
+        var declaringType = methodDec.Parent;
+        while (declaringType is not null && declaringType is not TypeDeclarationSyntax) declaringType = declaringType.Parent;
+
+        if (declaringType is InterfaceDeclarationSyntax) return; // don't flag on interfaces
+        
+        // exemption for classes implementing IAsyncApiAction
+        if (declaringType is ClassDeclarationSyntax classDec)
+        {
+            var baseTypeList = classDec.BaseList?.ChildNodes().OfType<SimpleBaseTypeSyntax>().SelectMany(baseTypeDec => baseTypeDec.ChildNodes());
+            if (baseTypeList != null && baseTypeList.Any(b => b is IdentifierNameSyntax { Identifier.Text: "IAsyncApiAction" })) return;
+        }
+        
+        context.ReportDiagnostic(Diagnostic.Create(MethodsReturningTaskMustBeAsync, methodDec.Identifier.GetLocation()));
+    }
+}

--- a/source/RoslynAnalyzers/Descriptors.cs
+++ b/source/RoslynAnalyzers/Descriptors.cs
@@ -36,13 +36,13 @@ namespace Octopus.RoslynAnalyzers
 
         // ----- General Analyzers that apply everywhere. Informally in the OCT1xxx number range ------
 
-        // public static readonly DiagnosticDescriptor VoidMethodsMustNotBeAsync = new(
-        //     "OCT1001",
-        //     "Void methods must not be async.",
-        //     "Void methods must not be async.",
-        //     Category,
-        //     DiagnosticSeverity.Error,
-        //     true);
+        public static readonly DiagnosticDescriptor VoidMethodsMustNotBeAsync = new(
+            "OCT1001",
+            "Void methods must not be async.",
+            "Void methods must not be async.",
+            Category,
+            DiagnosticSeverity.Error,
+            true);
         //
         // public static readonly DiagnosticDescriptor AsyncMethodsMustNotHaveAsyncSuffix = new(
         //     "OCT1002",

--- a/source/RoslynAnalyzers/Descriptors.cs
+++ b/source/RoslynAnalyzers/Descriptors.cs
@@ -34,6 +34,61 @@ namespace Octopus.RoslynAnalyzers
             Environment.NewLine +
             "Reach out to @team-core-blue if you need any help with strategies to test efficiently without base classes.";
 
+        // ----- General Analyzers that apply everywhere. Informally in the OCT1xxx number range ------
+
+        // public static readonly DiagnosticDescriptor VoidMethodsMustNotBeAsync = new(
+        //     "OCT1001",
+        //     "Void methods must not be async.",
+        //     "Void methods must not be async.",
+        //     Category,
+        //     DiagnosticSeverity.Error,
+        //     true);
+        //
+        // public static readonly DiagnosticDescriptor AsyncMethodsMustNotHaveAsyncSuffix = new(
+        //     "OCT1002",
+        //     "Async methods must not be named with an 'Async' suffix.",
+        //     "Async methods must not be named with an 'Async' suffix.",
+        //     Category,
+        //     DiagnosticSeverity.Error,
+        //     true);
+        
+        public static readonly DiagnosticDescriptor MethodsReturningTaskMustBeAsync = new(
+            "OCT1003",
+            "Methods returning Task must be async.",
+            "Methods returning Task must be async.",
+            Category,
+            DiagnosticSeverity.Error,
+            true);
+
+        // // Might not want to do this one as it has a lot of exemptions. Or maybe only have it at info level?
+        // public static readonly DiagnosticDescriptor AsyncMethodsMustTakeACancellationToken = new(
+        //     "OCT1004",
+        //     "Async methods must take a CancellationToken.",
+        //     "Async methods must take a CancellationToken.",
+        //     Category,
+        //     DiagnosticSeverity.Error,
+        //     true);
+        
+        // // Might not want to do this one as it has a lot of exemptions. Or maybe only have it at info level?
+        // public static readonly DiagnosticDescriptor MustNotBlockOnTaskResults = new(
+        //     "OCT1005",
+        //     "Must not Block on Task Results.",
+        //     "Must not Block on Task Results.",
+        //     Category,
+        //     DiagnosticSeverity.Error,
+        //     true);
+        //
+        // // Might not want to do this one. Or maybe only have it at info level?
+        // public static readonly DiagnosticDescriptor MustNotUseGetAwaiterExplicitly = new(
+        //     "OCT1006",
+        //     "Must not use GetAwaiter explicitly.",
+        //     "Must not use GetAwaiter explicitly.",
+        //     Category,
+        //     DiagnosticSeverity.Error,
+        //     true);
+        
+        // ----- Analyzers to help with Tests. Informally in the OCT2xxx number range -----
+        
         public static DiagnosticDescriptor Oct2001NoIntegrationTestBaseClasses => GetTestAnalyzerDescriptor(
             "OCT2001",
             "Integration test classes should inherit directly from IntegrationTest",
@@ -87,7 +142,7 @@ Any other complex logic or state should be in builders, class/assembly fixtures,
                 + "or pass in 'CancellationToken.None' explicitly to indicate intentionally not propagating the token.");
         }
         
-        // ----- Message Contract Analyzers -----
+        // ----- Message Contract Analyzers. Informally in the OCT30xx number range -----
         
         const string Category = "Octopus";
 
@@ -204,5 +259,10 @@ Any other complex logic or state should be in builders, class/assembly fixtures,
             Category,
             DiagnosticSeverity.Error,
             true);
+        
+        // ----- Controller / Handler Analyzers. Informally in the OCT32xx range
+        
+        
+        
     }
 }

--- a/source/RoslynAnalyzers/MessageContractAnalyzers.cs
+++ b/source/RoslynAnalyzers/MessageContractAnalyzers.cs
@@ -6,8 +6,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System;
-using System.Diagnostics;
-using System.Threading;
 using static Octopus.RoslynAnalyzers.Descriptors;
 
 namespace Octopus.RoslynAnalyzers

--- a/source/Tests/AsyncAnalyzerFixture.cs
+++ b/source/Tests/AsyncAnalyzerFixture.cs
@@ -94,6 +94,29 @@ namespace Octopus.Core
                 .Select(i => new DiagnosticResult(Descriptors.MethodsReturningTaskMustBeAsync).WithLocation(i))
                 .ToArray()); 
         }
+        
+        [Test]
+        public async Task VoidMethodsMustNotBeAsync()
+        {
+            var source = WithOctopusTypes(@"
+namespace Octopus.Core
+{
+  static class SomeClass
+  {
+    static int PlainOldMethodReturningInt(CancellationToken cancellationToken) => 0;
+
+    static void RegularVoidMethod()
+    { }
+
+    static async void {|#0:AsyncVoidMethod|}()
+    { await Task.CompletedTask; }
+  }
+}");
+            await Verify.VerifyAnalyzerAsync(source, 
+                Enumerable.Range(0, 1)
+                .Select(i => new DiagnosticResult(Descriptors.VoidMethodsMustNotBeAsync).WithLocation(i))
+                .ToArray()); 
+        }
 
         static readonly string AsyncTestTypeDeclarations = @"
 namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Web.Api

--- a/source/Tests/AsyncAnalyzerFixture.cs
+++ b/source/Tests/AsyncAnalyzerFixture.cs
@@ -1,0 +1,110 @@
+﻿using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+using Octopus.RoslynAnalyzers;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Verify = Microsoft.CodeAnalysis.CSharp.Testing.NUnit.AnalyzerVerifier<Octopus.RoslynAnalyzers.AsyncAnalyzer>;
+
+namespace Tests
+{
+    public class AsyncAnalyzerFixture
+    {
+        [Test]
+        public async Task NoDiagnosticsOnWellFormedRequest()
+        {
+            var source = WithOctopusTypes(@"
+namespace Octopus.Core
+{
+  static class SomeClass
+  {
+     static async Task NormalMethodWithNoReturnValue(CancellationToken cancellationToken)
+     { } 
+  }
+}");
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+        
+        [Test]
+        public async Task MethodsReturningTaskMustBeAsync()
+        {
+            var source = WithOctopusTypes(@"
+using Octopus.Server.Extensibility.Extensions.Infrastructure.Web.Api;
+namespace Octopus.Core
+{
+  public interface SomeInterface
+  {
+    Task NonAsyncMethodReturningTask(CancellationToken cancellationToken);
+  }
+
+  public abstract class SomeAbstractClass
+  {
+    public abstract Task NonAsyncMethodReturningTask(CancellationToken cancellationToken); // doesn't flag on this because it's abstract
+  }
+
+  public class SomeDerivedClass : SomeAbstractClass
+  {
+    public override Task {|#0:NonAsyncMethodReturningTask|}(CancellationToken cancellationToken) // we should flag when we implement the abstract method
+    { return Task.CompletedTask; }
+  }
+
+  public abstract class AsyncApiActionClass : IAsyncApiAction
+  {
+    public Task NonAsyncMethodReturningTask(CancellationToken cancellationToken) => Task.FromResult(""foo""); // doesn't flag on this because the class implements IAsyncApiAction
+    public Task<string> ExecuteAsync(string request) => Task.FromResult(""foo"");
+  }
+
+  static class SomeClass
+  {
+    static int PlainOldMethodReturningInt(CancellationToken cancellationToken) => 0;
+
+    static async Task AsyncMethodReturningTask(CancellationToken cancellationToken)
+    { await Task.CompletedTask; }
+
+    static Task {|#1:NonAsyncMethodReturningTask|}(CancellationToken cancellationToken)
+    { return Task.FromResult(true); }
+
+    static Task<int> {|#2:NonAsyncMethodReturningTaskOfInt|}(CancellationToken cancellationToken)
+    { return Task.FromResult(1); }
+
+    static Task<string> {|#3:NonAsyncMethodReturningTaskOfString|}(CancellationToken cancellationToken)
+    { return Task.FromResult(""x""); } 
+
+    static ValueTask {|#4:NonAsyncMethodReturningValueTask|}(CancellationToken cancellationToken)
+    { return new ValueTask(); } 
+
+    static ValueTask<string> {|#5:NonAsyncMethodReturningValueTaskOfString|}(CancellationToken cancellationToken)
+    { return new ValueTask<string>(""x""); }
+
+    static void ContainerMethod()
+    {
+        static async Task AsyncMethodReturningTask(CancellationToken cancellationToken)
+        { await Task.CompletedTask; }
+
+        // NOTE: NO DIAGNOSTIC on this. We only scan for toplevel methods, not inner methods and lambdas.
+        // perhaps we should scan for inner things? At last visit (Dec 2022) the reflection based test didn't catch these
+        // and we are aiming for parity with that, so decided to leave that discussion for another day.
+        static Task NonAsyncMethodReturningTask(CancellationToken cancellationToken)
+        { return Task.FromResult(true); }
+    }
+  }
+}");
+            await Verify.VerifyAnalyzerAsync(source, 
+                Enumerable.Range(0, 6)
+                .Select(i => new DiagnosticResult(Descriptors.MethodsReturningTaskMustBeAsync).WithLocation(i))
+                .ToArray()); 
+        }
+
+        static readonly string AsyncTestTypeDeclarations = @"
+namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Web.Api
+{
+    public interface IAsyncApiAction
+    {
+        Task<string> ExecuteAsync(string request); // the real IAsyncApiAction uses IOctoRequest and IOctoResponse. The analyzer doesn't care so we can sub them during tests
+    }
+}
+";
+        
+        static string WithOctopusTypes(string source) => $"{Common.Usings}{source}{Common.MessageTypeDeclarations}{AsyncTestTypeDeclarations}";
+    }
+}

--- a/source/Tests/MessageContractAnalyzerFixture.cs
+++ b/source/Tests/MessageContractAnalyzerFixture.cs
@@ -582,6 +582,8 @@ namespace Octopus.TinyTypes
                 "System",
                 "System.Collections.Generic",
                 "System.ComponentModel.DataAnnotations",
+                "System.Threading",
+                "System.Threading.Tasks",
                 "Octopus.Server.MessageContracts",
                 "Octopus.Server.MessageContracts.Base",
                 "Octopus.Server.MessageContracts.Base.Attributes",


### PR DESCRIPTION
Continuing the convention analyzer trend, this PR adds two more:

- VoidMethodsMustNotBeAsync
- MethodsReturningTaskMustBeAsync

https://docs.google.com/document/d/1KSWMYMCRdDe4PR0GPeeQX_zXnTFClGUu5TOcGhmoHeA/edit#