### PR TITLE
Analyzers for MVC Controllers - OCT3201 and OCT3202

### DIFF
--- a/source/RoslynAnalyzers/AnalyzerExtensionMethods.cs
+++ b/source/RoslynAnalyzers/AnalyzerExtensionMethods.cs
@@ -47,17 +47,16 @@ namespace Octopus.RoslynAnalyzers
 
             return false;
         }
-        
+
         /// <summary>Returns true if sourceType inherits from baseType, walking down the type hierarchy as far as it can</summary>
         public static bool InheritsFrom(this ITypeSymbol? sourceType, ITypeSymbol? baseType)
         {
-            if (sourceType?.BaseType is not { } candidate) return false;
-
-            while (candidate != null)
+            var candidate = sourceType?.BaseType;
+            while (candidate != null && candidate.MetadataName != "Object")
             {
                 if (SymbolEqualityComparer.Default.Equals(candidate, baseType)) return true;
 
-                candidate = candidate.BaseType?.MetadataName == "Object" ? null : candidate.BaseType;
+                candidate = candidate.BaseType;
             }
 
             return false;

--- a/source/RoslynAnalyzers/AnalyzerExtensionMethods.cs
+++ b/source/RoslynAnalyzers/AnalyzerExtensionMethods.cs
@@ -47,7 +47,23 @@ namespace Octopus.RoslynAnalyzers
 
             return false;
         }
+        
+        /// <summary>Returns true if sourceType inherits from baseType, walking down the type hierarchy as far as it can</summary>
+        public static bool InheritsFrom(this ITypeSymbol? sourceType, ITypeSymbol? baseType)
+        {
+            if (sourceType?.BaseType is not { } candidate) return false;
 
+            while (candidate != null)
+            {
+                if (SymbolEqualityComparer.Default.Equals(candidate, baseType)) return true;
+
+                candidate = candidate.BaseType?.MetadataName == "Object" ? null : candidate.BaseType;
+            }
+
+            return false;
+        }
+
+        /// <summary>Returns true if sourceType directly inherits from baseType. Does not consider any kind of hierarchy</summary>
         public static bool DirectlyInheritsFrom(this ITypeSymbol? sourceType, ITypeSymbol? baseType)
         {
             return sourceType?.BaseType != null && SymbolEqualityComparer.Default.Equals(sourceType.BaseType, baseType);

--- a/source/RoslynAnalyzers/ApiControllerAnalyzer.cs
+++ b/source/RoslynAnalyzers/ApiControllerAnalyzer.cs
@@ -1,0 +1,155 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Octopus.RoslynAnalyzers;
+using static Descriptors;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public partial class ApiControllerAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+        MustNotHaveSwaggerOperationAttribute,
+        MustNotReturnActionResults);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        if(!Debugger.IsAttached) context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(CheckNode, SyntaxKind.ClassDeclaration);
+    }
+
+    void CheckNode(SyntaxNodeAnalysisContext context)
+    {
+        if (context.Node is not ClassDeclarationSyntax classDec || !IsApiController(context, classDec)) return;
+  
+        var attrNames = classDec.AttributeLists.SelectMany(al => al.Attributes.Select(a => (a.Name as IdentifierNameSyntax)?.Identifier.Text));
+        var isExperimental = attrNames.Any(a => a == "Experimental");
+
+        var actionMethods = new List<MethodDeclarationSyntax>();
+        foreach (var methodDec in classDec.DescendantNodes().OfType<MethodDeclarationSyntax>())
+        {
+            // only validate action methods
+            if(!IsActionMethod(context, methodDec)) continue;
+            actionMethods.Add(methodDec);
+
+            if (!isExperimental)
+            {
+                MustNot_HaveSwaggerOperationAttribute(context, methodDec);
+            }
+
+            MustNot_ReturnActionResults(context, methodDec);
+        }
+
+        // ControllersAcceptingNewPayloads_MustBeNamedCorrectly();
+    }
+
+    static bool MustNot_HaveSwaggerOperationAttribute(SyntaxNodeAnalysisContext context, MethodDeclarationSyntax methodDec)
+    {
+        var swaggerOperationAttr = methodDec.AttributeLists.SelectMany(al => al.Attributes).FirstOrDefault(al => al.Name is IdentifierNameSyntax { Identifier.Text: "SwaggerOperation" });
+        if (swaggerOperationAttr != null)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(MustNotHaveSwaggerOperationAttribute,
+                location: swaggerOperationAttr.GetLocation()));
+            return false;
+        }
+
+        return true;
+    }
+    
+    static bool MustNot_ReturnActionResults(SyntaxNodeAnalysisContext context, MethodDeclarationSyntax methodDec)
+    {
+        var returnType = context.SemanticModel.GetTypeInfo(methodDec.ReturnType);
+        if (returnType.Type is not INamedTypeSymbol namedTypeSymbol) return true; // not something we care about
+
+        var typeSymbol = namedTypeSymbol.UnwrapTaskOf();
+
+        var actionResultType = context.Compilation.GetTypeByMetadataName("Microsoft.AspNetCore.Mvc.IActionResult");
+        var convertToActionResultType = context.Compilation.GetTypeByMetadataName("Microsoft.AspNetCore.Mvc.Infrastructure.IConvertToActionResult");
+
+        var symCmp = SymbolEqualityComparer.Default;
+        if (symCmp.Equals(typeSymbol, actionResultType) || symCmp.Equals(typeSymbol, convertToActionResultType))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(MustNotReturnActionResults, location: methodDec.ReturnType.GetLocation()));
+            return false;
+        }
+        
+        // if they didn't directly return IActionResult, then check the interface hierarchy
+        if (typeSymbol.AllInterfaces.Any(a => symCmp.Equals(a, actionResultType) || symCmp.Equals(a, convertToActionResultType)))
+        {
+            // exemptions for specific types
+            if (symCmp.Equals(typeSymbol, context.Compilation.GetTypeByMetadataName("Microsoft.AspNetCore.Mvc.FileResult"))) return true;
+            if (symCmp.Equals(typeSymbol, context.Compilation.GetTypeByMetadataName("Octopus.Server.Web.Infrastructure.BlobResult"))) return true;
+            if (symCmp.Equals(typeSymbol, context.Compilation.GetTypeByMetadataName("Octopus.Server.Web.Infrastructure.CsvFileResult"))) return true;
+            if (symCmp.Equals(typeSymbol, context.Compilation.GetTypeByMetadataName("Octopus.Server.Web.Controllers.Telemetry.AmplitudeOkResult"))) return true;
+            if (symCmp.Equals(typeSymbol.OriginalDefinition, context.Compilation.GetTypeByMetadataName("Microsoft.AspNetCore.Mvc.CreatedResult`1"))) return true; // only CreatedResult<T> is allowed, the non-generic one isn't
+            
+            context.ReportDiagnostic(Diagnostic.Create(MustNotReturnActionResults, location: methodDec.ReturnType.GetLocation()));
+            return false;
+        }
+        
+        return true;
+    }
+
+    /// <summary>
+    /// Returns a guess at whether a method on a controller is an MVC action method.
+    /// </summary>
+    static bool IsActionMethod(SyntaxNodeAnalysisContext context, MethodDeclarationSyntax methodDec)
+    {
+        var isPublic = false;
+        foreach (var s in methodDec.Modifiers)
+        {
+            if (s.IsKind(SyntaxKind.PublicKeyword)) isPublic = true;
+
+            if (s.IsKind(SyntaxKind.StaticKeyword)) return false;
+            if (s.IsKind(SyntaxKind.AbstractKeyword)) return false;
+            if (s.IsKind(SyntaxKind.ConstructorDeclaration)) return false;
+        }
+
+        if (!isPublic) return false;
+
+        var isObviouslyActionMethod = false;
+        foreach (var attr in methodDec.AttributeLists.SelectMany(al => al.Attributes))
+        {
+            if(attr.Name is not IdentifierNameSyntax { Identifier.Text: var identifierText }) continue;
+
+            switch (identifierText)
+            {
+                case "Route":
+                case "HttpGet":
+                case "HttpPost":
+                case "HttpPut":
+                case "HttpDelete":
+                    isObviouslyActionMethod = true;
+                    break;
+            }
+        }
+        
+        // TODO someone could have made a custom subclass of HttpGet, we'd need to walk the inheritance tree here to catch it.
+        // TODO that work goes here later.
+
+        return isObviouslyActionMethod;
+    }
+
+    static bool IsApiController(SyntaxNodeAnalysisContext context, ClassDeclarationSyntax classDec)
+    {
+        var isPublic = false;
+        foreach (var s in classDec.Modifiers)
+        {
+            if (s.IsKind(SyntaxKind.PublicKeyword)) isPublic = true;
+
+            if (s.IsKind(SyntaxKind.StaticKeyword)) return false;
+            if (s.IsKind(SyntaxKind.AbstractKeyword)) return false;
+        }
+        if(!isPublic) return false;
+        
+        var symbol = context.SemanticModel.GetDeclaredSymbol(classDec);
+        var controllerBaseType = context.Compilation.GetTypeByMetadataName("Microsoft.AspNetCore.Mvc.ControllerBase");
+        return symbol.InheritsFrom(controllerBaseType);
+    }
+}

--- a/source/RoslynAnalyzers/AsyncAnalyzer.cs
+++ b/source/RoslynAnalyzers/AsyncAnalyzer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -15,7 +14,6 @@ using static Descriptors;
 public class AsyncAnalyzer : DiagnosticAnalyzer
 {
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
-        VoidMethodsMustNotBeAsync,
         MethodsReturningTaskMustBeAsync);
 
     public override void Initialize(AnalysisContext context)
@@ -32,19 +30,12 @@ public class AsyncAnalyzer : DiagnosticAnalyzer
         var isAsync = methodDec.Modifiers.Any(SyntaxKind.AsyncKeyword);
         if (isAsync)
         {
-            VoidMethods_MustNotBeAsync(context, methodDec);
+            // future analyzers targeting async methods go here
+            // such as AsyncMethodsMustNotHaveAsyncSuffix and AsyncMethodsMustTakeACancellationToken
         }
         else
         {
             MethodsReturningTask_MustBeAsync(context, methodDec);
-        }
-    }
-
-    void VoidMethods_MustNotBeAsync(SyntaxNodeAnalysisContext context, MethodDeclarationSyntax methodDec)
-    {
-        if (methodDec.ReturnType is PredefinedTypeSyntax p && p.Keyword.IsKind(SyntaxKind.VoidKeyword))
-        {
-            context.ReportDiagnostic(Diagnostic.Create(VoidMethodsMustNotBeAsync, methodDec.Identifier.GetLocation()));
         }
     }
 

--- a/source/RoslynAnalyzers/Descriptors.cs
+++ b/source/RoslynAnalyzers/Descriptors.cs
@@ -262,7 +262,20 @@ Any other complex logic or state should be in builders, class/assembly fixtures,
         
         // ----- Controller / Handler Analyzers. Informally in the OCT32xx range
         
+        public static readonly DiagnosticDescriptor MustNotHaveSwaggerOperationAttribute = new(
+            "OCT3201",
+            "Do not use SwaggerOperationAttribute.",
+            "Do not use SwaggerOperationAttribute",
+            Category,
+            DiagnosticSeverity.Error,
+            true);
         
-        
+        public static readonly DiagnosticDescriptor MustNotReturnActionResults = new(
+            "OCT3202",
+            "Must not return ActionResults.",
+            "Must not return ActionResults",
+            Category,
+            DiagnosticSeverity.Error,
+            true);
     }
 }

--- a/source/RoslynAnalyzers/Descriptors.cs
+++ b/source/RoslynAnalyzers/Descriptors.cs
@@ -36,6 +36,7 @@ namespace Octopus.RoslynAnalyzers
 
         // ----- General Analyzers that apply everywhere. Informally in the OCT1xxx number range ------
 
+        [Obsolete("Removed; The third party AsyncFixer analyzer also cover this exact same thing")]
         public static readonly DiagnosticDescriptor VoidMethodsMustNotBeAsync = new(
             "OCT1001",
             "Void methods must not be async.",

--- a/source/RoslynAnalyzers/MessageContractAnalyzers.cs
+++ b/source/RoslynAnalyzers/MessageContractAnalyzers.cs
@@ -204,7 +204,7 @@ namespace Octopus.RoslynAnalyzers
         {
             var propType = propDec.Type is NullableTypeSyntax n ? n.ElementType : propDec.Type;
 
-            var typeInfo = context.SemanticModel.GetTypeInfo(propType);
+            var typeInfo = context.SemanticModel.GetTypeInfo(propType, context.CancellationToken);
             if (typeInfo.Type == null) return false;
 
             var enumerableType = context.Compilation.GetSpecialType(SpecialType.System_Collections_IEnumerable);

--- a/source/RoslynAnalyzers/SemanticModelExtensionMethods.cs
+++ b/source/RoslynAnalyzers/SemanticModelExtensionMethods.cs
@@ -35,7 +35,7 @@ namespace Octopus.RoslynAnalyzers
                 : GetTopMostNamespace(ns.ContainingNamespace);
         
         // If `type` is a Task<T> or ValueTask<T> then this returns the T.
-        // otherwise type is just returned untouched
+        // otherwise `type` is just returned as-is.
         public static ITypeSymbol UnwrapTaskOf(this INamedTypeSymbol type)
         {
             if (type.IsGenericType && type.Name is "Task" or "ValueTask" && type.TypeArguments.Length > 0)
@@ -45,9 +45,5 @@ namespace Octopus.RoslynAnalyzers
 
             return type;
         }
-            // => type.IsGenericType &&
-            //     type.TypeArguments.Length == numberOfGenericParameters &&
-            //     type.Name == name &&
-            //     type.IsInNamespace(namespaceParts);
     }
 }

--- a/source/RoslynAnalyzers/SemanticModelExtensionMethods.cs
+++ b/source/RoslynAnalyzers/SemanticModelExtensionMethods.cs
@@ -33,5 +33,21 @@ namespace Octopus.RoslynAnalyzers
             => ns.IsGlobalNamespace || ns.ContainingNamespace.IsGlobalNamespace
                 ? ns
                 : GetTopMostNamespace(ns.ContainingNamespace);
+        
+        // If `type` is a Task<T> or ValueTask<T> then this returns the T.
+        // otherwise type is just returned untouched
+        public static ITypeSymbol UnwrapTaskOf(this INamedTypeSymbol type)
+        {
+            if (type.IsGenericType && type.Name is "Task" or "ValueTask" && type.TypeArguments.Length > 0)
+            {
+                return type.TypeArguments[0];
+            }
+
+            return type;
+        }
+            // => type.IsGenericType &&
+            //     type.TypeArguments.Length == numberOfGenericParameters &&
+            //     type.Name == name &&
+            //     type.IsInNamespace(namespaceParts);
     }
 }

--- a/source/Tests/ApiControllerAnalyzerFixture.cs
+++ b/source/Tests/ApiControllerAnalyzerFixture.cs
@@ -1,0 +1,231 @@
+﻿using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+using Octopus.RoslynAnalyzers;
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework.Internal;
+using Verify = Microsoft.CodeAnalysis.CSharp.Testing.NUnit.AnalyzerVerifier<Octopus.RoslynAnalyzers.ApiControllerAnalyzer>;
+
+namespace Tests
+{
+    public class ApiControllerAnalyzerFixture
+    {
+        [Test]
+        public async Task NoDiagnosticsOnWellFormedRequest()
+        {
+            var source = WithOctopusTypes(@"
+namespace Octopus.Core
+{
+  public class GetFooController : ControllerBase {
+    public GetFooResponse GetFoo(GetFooRequest request) => new();
+  }
+}");
+            await Verify.VerifyAnalyzerAsync(source);
+        }
+
+        [Test]
+        public async Task MustNotHaveSwaggerOperationAttribute()
+        {
+            var source = WithOctopusTypes(@"
+namespace Octopus.Core
+{
+  namespace A {
+    public class GetFooController : ControllerBase {
+      [HttpGet(""/api/foos"")]
+      [{|#0:SwaggerOperation(""some swagger thing"")|}]
+      public GetFooResponse GetFoo(GetFooRequest request) => new();
+    }
+  }
+
+  namespace B {
+    [Experimental] // should not fire on experimental
+    public class GetFooController : ControllerBase {
+      [HttpGet(""/api/foos"")]
+      [SwaggerOperation(""some swagger thing"")]
+      public GetFooResponse GetFoo(GetFooRequest request) => new();
+    }
+  }
+
+  namespace C {
+    // should not fire on nonpublic method
+    public class GetFooController : ControllerBase {
+      [HttpGet(""/api/foos"")]
+      [SwaggerOperation(""some swagger thing"")]
+      GetFooResponse GetFoo(GetFooRequest request) => new();
+    }
+  }
+}");
+            await Verify.VerifyAnalyzerAsync(source,
+                new DiagnosticResult(Descriptors.MustNotHaveSwaggerOperationAttribute).WithLocation(0));
+        }
+
+        [Test]
+        public async Task MustNotReturnActionResults()
+        {
+            var source = WithOctopusTypes(@"
+namespace Octopus.ApiControllerTests.Good {
+  namespace A {
+    public class GetFooController : ControllerBase {
+      [HttpGet(""/api/foos"")]
+      public string GetFoo(GetFooRequest request) => ""some string"";
+    }
+  }
+  namespace A_Task {
+    public class GetFooController : ControllerBase {
+      [HttpGet(""/api/foos"")]
+      public async Task<string> GetFoo(GetFooRequest request) {
+        await Task.CompletedTask;
+        return ""some string"";
+      }
+    }
+  }
+}
+
+namespace Octopus.ApiControllerTests.Violations
+{
+  namespace A {
+    public class GetFooController : ControllerBase {
+      [HttpGet(""/api/foos"")]
+      public {|#0:IActionResult|} GetFoo(GetFooRequest request) => new ObjectResult();
+    }
+  }
+  namespace A_Task {
+    public class GetFooController : ControllerBase {
+      [HttpGet(""/api/foos"")]
+      public async {|#1:Task<IActionResult>|} GetFoo(GetFooRequest request) {
+        await Task.CompletedTask;
+        return new ObjectResult();
+      }
+    }
+  }
+
+  namespace B {
+    public class GetFooController : ControllerBase {
+      [HttpGet(""/api/foos"")]
+      public {|#2:ContentResult|} GetFoo(GetFooRequest request) => new ContentResult();
+    }
+  }
+    
+  namespace C {
+    public class GetFooController : ControllerBase {
+      [HttpGet(""/api/foos"")]
+      public {|#3:CreatedResult|} GetFoo(GetFooRequest request) => new CreatedResult();
+    }
+  }
+
+  namespace D {
+    public class GetFooController : ControllerBase {
+      [HttpGet(""/api/foos"")]
+      public {|#4:ConvertibleToActionResult|} GetFoo(GetFooRequest request) => new ConvertibleToActionResult();
+    }
+  }
+  namespace D_Task {
+    public class GetFooController : ControllerBase {
+      [HttpGet(""/api/foos"")]
+      public async {|#5:Task<ConvertibleToActionResult>|} GetFoo(GetFooRequest request) {
+        await Task.CompletedTask;
+        return new ConvertibleToActionResult();
+      }
+    }
+  }
+}
+
+namespace Octopus.ApiControllerTests.Exempt {
+  namespace A {
+    public class GetFooController : ControllerBase {
+      [HttpGet(""/api/foos"")]
+      public CreatedResult<string> GetFoo(GetFooRequest request) => new CreatedResult<string>();
+    }
+  }
+  namespace A_Task {
+    public class GetFooController : ControllerBase {
+      [HttpGet(""/api/foos"")]
+      public Task<CreatedResult<string>> GetFoo(GetFooRequest request) => Task.FromResult(new CreatedResult<string>());
+    }
+  }
+
+  namespace B {
+    public class GetFooController : ControllerBase {
+      [HttpGet(""/api/foos"")]
+      public Octopus.Server.Web.Controllers.Telemetry.AmplitudeOkResult GetFoo(GetFooRequest request) => new();
+    }
+  }
+
+  namespace C {
+    public class GetFooController : ControllerBase {
+      [HttpGet(""/api/foos"")]
+      public BlobResult GetFoo(GetFooRequest request) => new();
+    }
+  }
+
+  namespace D {
+    public class GetFooController : ControllerBase {
+      [HttpGet(""/api/foos"")]
+      public CsvFileResult GetFoo(GetFooRequest request) => new();
+    }
+  }
+
+  namespace E {
+    public class GetFooController : ControllerBase {
+      [HttpGet(""/api/foos"")]
+      public FileResult GetFoo(GetFooRequest request) => new();
+    }
+  }
+}");
+           
+            await Verify.VerifyAnalyzerAsync(source,
+                new DiagnosticResult(Descriptors.MustNotReturnActionResults).WithLocation(0),
+                new DiagnosticResult(Descriptors.MustNotReturnActionResults).WithLocation(1),
+                new DiagnosticResult(Descriptors.MustNotReturnActionResults).WithLocation(2),
+                new DiagnosticResult(Descriptors.MustNotReturnActionResults).WithLocation(3),
+                new DiagnosticResult(Descriptors.MustNotReturnActionResults).WithLocation(4),
+                new DiagnosticResult(Descriptors.MustNotReturnActionResults).WithLocation(5)
+            );
+        }
+
+        static readonly string ApiControllerTypeUsings = "using Microsoft.AspNetCore.Mvc;using Swashbuckle.AspNetCore.Annotations;using Octopus.Server.Web.Infrastructure;";
+
+        static readonly string ApiControllerTypeDeclarations = @"
+public class GetFooRequest : IRequest<GetFooRequest, GetFooResponse> { }
+public class GetFooResponse : IResponse { }
+
+namespace Microsoft.AspNetCore.Mvc {
+  public interface IActionResult { }
+  public abstract class ControllerBase { }
+
+  public abstract class HttpMethodAttribute : Attribute { }
+  public class HttpGetAttribute : HttpMethodAttribute {
+    public HttpGetAttribute(string route) { } 
+  }
+
+  public abstract class ActionResult : IActionResult { }
+  public class ContentResult : ActionResult { }
+  public class ObjectResult : ActionResult { }
+  public class CreatedResult : ObjectResult { }
+  public class CreatedResult<TResponse> : CreatedResult { }
+  public class FileResult : ActionResult { }
+
+  namespace Infrastructure {
+    public interface IConvertToActionResult { }
+  }
+}
+namespace Octopus.Server.Web.Infrastructure {
+  public class CsvFileResult : ActionResult { }
+  public class BlobResult : FileResult { }
+
+  public class ConvertibleToActionResult : Microsoft.AspNetCore.Mvc.Infrastructure.IConvertToActionResult { }
+}
+namespace Octopus.Server.Web.Controllers.Telemetry {
+  public class AmplitudeOkResult : ContentResult { }
+}
+namespace Swashbuckle.AspNetCore.Annotations {
+  public class SwaggerOperationAttribute : Attribute 
+  {
+    public SwaggerOperationAttribute(string summary) : base() { }
+  }
+}
+";
+
+        static string WithOctopusTypes(string source) => $"{Common.Usings}{ApiControllerTypeUsings}{source}{Common.MessageTypeDeclarations}{ApiControllerTypeDeclarations}";
+    }
+}

--- a/source/Tests/AsyncAnalyzerFixture.cs
+++ b/source/Tests/AsyncAnalyzerFixture.cs
@@ -95,29 +95,6 @@ namespace Octopus.Core
                 .ToArray()); 
         }
         
-        [Test]
-        public async Task VoidMethodsMustNotBeAsync()
-        {
-            var source = WithOctopusTypes(@"
-namespace Octopus.Core
-{
-  static class SomeClass
-  {
-    static int PlainOldMethodReturningInt(CancellationToken cancellationToken) => 0;
-
-    static void RegularVoidMethod()
-    { }
-
-    static async void {|#0:AsyncVoidMethod|}()
-    { await Task.CompletedTask; }
-  }
-}");
-            await Verify.VerifyAnalyzerAsync(source, 
-                Enumerable.Range(0, 1)
-                .Select(i => new DiagnosticResult(Descriptors.VoidMethodsMustNotBeAsync).WithLocation(i))
-                .ToArray()); 
-        }
-
         static readonly string AsyncTestTypeDeclarations = @"
 namespace Octopus.Server.Extensibility.Extensions.Infrastructure.Web.Api
 {


### PR DESCRIPTION
# Background

This PR is paired with https://github.com/OctopusDeploy/OctopusDeploy/pull/15928

Please refer to the RFC:
https://docs.google.com/document/d/1KSWMYMCRdDe4PR0GPeeQX_zXnTFClGUu5TOcGhmoHeA/edit

# Results

Implements new analyzers

`OCT3201:MustNotHaveSwaggerOperationAttribute`
`OCT3202:MustNotReturnActionResults`

And deletes `OCT1001:VoidMethodsMustNotBeAsync` as it is redundant. Identical functionality is provided by [AsyncFixer](https://github.com/semihokur/AsyncFixer)