### PR TITLE
Adds DontUseIDocumentStoreOfEvent

### DIFF
--- a/source/RoslynAnalyzers/ApiControllerAnalyzer.cs
+++ b/source/RoslynAnalyzers/ApiControllerAnalyzer.cs
@@ -11,7 +11,7 @@ namespace Octopus.RoslynAnalyzers;
 using static Descriptors;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public partial class ApiControllerAnalyzer : DiagnosticAnalyzer
+public class ApiControllerAnalyzer : DiagnosticAnalyzer
 {
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
         MustNotHaveSwaggerOperationAttribute,

--- a/source/RoslynAnalyzers/Descriptors.cs
+++ b/source/RoslynAnalyzers/Descriptors.cs
@@ -88,6 +88,15 @@ namespace Octopus.RoslynAnalyzers
         //     DiagnosticSeverity.Error,
         //     true);
         
+        
+        public static readonly DiagnosticDescriptor DontUseIDocumentStoreOfEvent = new(
+            id: "OCT1007",
+            title: "Use IReadOnlyDocumentStore<Event> or IEventStore instead of IDocumentStore<Event>.",
+            messageFormat: "Use IReadOnlyDocumentStore<Event> or IEventStore instead of IDocumentStore<Event>.",
+            category: Category,
+            defaultSeverity: DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+        
         // ----- Analyzers to help with Tests. Informally in the OCT2xxx number range -----
         
         public static DiagnosticDescriptor Oct2001NoIntegrationTestBaseClasses => GetTestAnalyzerDescriptor(

--- a/source/RoslynAnalyzers/PersistenceAnalyzers.cs
+++ b/source/RoslynAnalyzers/PersistenceAnalyzers.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Octopus.RoslynAnalyzers;
+
+using static Descriptors;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class PersistenceAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+        DontUseIDocumentStoreOfEvent);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        if (!Debugger.IsAttached) context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(DontUse_IDocumentStoreOfEvent, SyntaxKind.FieldDeclaration, SyntaxKind.PropertyDeclaration, SyntaxKind.ConstructorDeclaration);
+    }
+
+    // this flags declarations of fields or properties referencing IDocumentStore<Event, string>,
+    // as well as constructor parameters (assuming someone is importing it from Autofac)
+    // it doesn't flag on other things to reduce the effort required to check for this.
+    void DontUse_IDocumentStoreOfEvent(SyntaxNodeAnalysisContext context)
+    {
+        static void CheckForIDocumentStoreOfEvent(SyntaxNodeAnalysisContext context, TypeSyntax typeToCheck)
+        {
+            GenericNameSyntax genericNameSyntax;
+            switch (typeToCheck)
+            {
+                case GenericNameSyntax gns:
+                    genericNameSyntax = gns;
+                    break;
+                case NullableTypeSyntax { ElementType: GenericNameSyntax gns }:
+                    genericNameSyntax = gns;
+                    break;
+                default:
+                    return;
+            }
+
+            if (genericNameSyntax.Identifier.Text == "IDocumentStore" && genericNameSyntax.TypeArgumentList.Arguments.Count == 2)
+            {
+                if (genericNameSyntax.TypeArgumentList.Arguments[0] is IdentifierNameSyntax i && i.Identifier.Text == "Event")
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(DontUseIDocumentStoreOfEvent, genericNameSyntax.GetLocation()));
+                }
+            }
+        }
+        
+        ;
+        switch (context.Node)
+        {
+            case PropertyDeclarationSyntax propDec:
+                CheckForIDocumentStoreOfEvent(context, propDec.Type);
+                break;
+            case FieldDeclarationSyntax fieldDec:
+                CheckForIDocumentStoreOfEvent(context, fieldDec.Declaration.Type);
+                break;
+            case ConstructorDeclarationSyntax ctorDec:
+                foreach (var p in ctorDec.ParameterList.Parameters)
+                {
+                    if(p.Type is { } typeToCheck) CheckForIDocumentStoreOfEvent(context, typeToCheck);
+                }
+                break;
+            default:
+                return;
+        }
+
+        
+    }
+}

--- a/source/Tests/ApiControllerAnalyzerFixture.cs
+++ b/source/Tests/ApiControllerAnalyzerFixture.cs
@@ -3,7 +3,6 @@ using NUnit.Framework;
 using Octopus.RoslynAnalyzers;
 using System;
 using System.Threading.Tasks;
-using NUnit.Framework.Internal;
 using Verify = Microsoft.CodeAnalysis.CSharp.Testing.NUnit.AnalyzerVerifier<Octopus.RoslynAnalyzers.ApiControllerAnalyzer>;
 
 namespace Tests

--- a/source/Tests/PersistenceAnalyzerFixture.cs
+++ b/source/Tests/PersistenceAnalyzerFixture.cs
@@ -1,0 +1,143 @@
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+using Octopus.RoslynAnalyzers;
+using System;
+using System.Threading.Tasks;
+using Verify = Microsoft.CodeAnalysis.CSharp.Testing.NUnit.AnalyzerVerifier<Octopus.RoslynAnalyzers.PersistenceAnalyzer>;
+
+namespace Tests
+{
+    public class PersistenceAnalyzerFixture
+    {
+        [Test]
+        public async Task DiagnosticOnFields()
+        {
+            var source = WithOctopusTypes(@"
+namespace Octopus.Core {
+  public class SomeClass {
+    readonly {|#0:IDocumentStore<Event, string>|} readonlyField = null!;
+    {|#1:IDocumentStore<Event, string>|} mutableField = null!;
+    static readonly {|#2:IDocumentStore<Event, string>|} staticReadonlyField = null!;
+     
+    readonly {|#3:IDocumentStore<Event, string>|}? readonlyNullableField = null!;
+    {|#4:IDocumentStore<Event, string>|}? mutableNullableField = null;
+    static readonly {|#5:IDocumentStore<Event, string>|}? staticReadonlyNullableField = null;
+
+    // these are allowed (IReadOnlyDocumentStore)
+    readonly IReadOnlyDocumentStore<Event, string> readonlyFieldRODS = null!;
+    IReadOnlyDocumentStore<Event, string> mutableFieldRODS = null!;
+    static readonly IReadOnlyDocumentStore<Event, string> staticReadonlyFieldRODS = null!;
+     
+    readonly IReadOnlyDocumentStore<Event, string>? readonlyNullableFieldRODS = null!;
+    IReadOnlyDocumentStore<Event, string>? mutableNullableFieldRODS = null;
+    static readonly IReadOnlyDocumentStore<Event, string>? staticReadonlyNullableFieldRODS = null;
+
+    // these are allowed (not Event)
+    readonly IDocumentStore<Project, string> readonlyFieldNotEvent = null!;
+    IDocumentStore<Project, string> mutableFieldNotEvent = null!;
+    static readonly IDocumentStore<Project, string> staticReadonlyFieldNotEvent = null!;
+     
+    readonly IDocumentStore<Project, string>? readonlyNullableFieldNotEvent = null!;
+    IDocumentStore<Project, string>? mutableNullableFieldNotEvent = null;
+    static readonly IDocumentStore<Project, string>? staticReadonlyNullableFieldNotEvent = null;
+  }
+}");
+            await Verify.VerifyAnalyzerAsync(source,
+                new DiagnosticResult(Descriptors.DontUseIDocumentStoreOfEvent).WithLocation(0),
+                new DiagnosticResult(Descriptors.DontUseIDocumentStoreOfEvent).WithLocation(1),
+                new DiagnosticResult(Descriptors.DontUseIDocumentStoreOfEvent).WithLocation(2),
+                new DiagnosticResult(Descriptors.DontUseIDocumentStoreOfEvent).WithLocation(3),
+                new DiagnosticResult(Descriptors.DontUseIDocumentStoreOfEvent).WithLocation(4),
+                new DiagnosticResult(Descriptors.DontUseIDocumentStoreOfEvent).WithLocation(5));
+        }
+        
+        [Test]
+        public async Task DiagnosticOnProperties()
+        {
+            var source = WithOctopusTypes(@"
+namespace Octopus.Core {
+  public class SomeClass {
+    {|#0:IDocumentStore<Event, string>|} ReadonlyProp {get;} = null!;
+    {|#1:IDocumentStore<Event, string>|} MutableProp {get;set;} = null!;
+    static {|#2:IDocumentStore<Event, string>|} StaticReadonlyProp {get;set;}= null!;
+     
+    {|#3:IDocumentStore<Event, string>|}? ReadonlyNullableProp {get;} = null!;
+    {|#4:IDocumentStore<Event, string>|}? MutableNullableProp {get;set;} = null;
+    static {|#5:IDocumentStore<Event, string>|}? StaticReadonlyNullableProp {get;set;} = null;
+
+    // these are allowed (IReadOnlyDocumentStore)
+    IReadOnlyDocumentStore<Event, string> ReadonlyPropRODS {get;} = null!;
+    IReadOnlyDocumentStore<Event, string> MutablePropRODS {get;set;} = null!;
+    static IReadOnlyDocumentStore<Event, string> StaticReadonlyPropRODS {get;set;} = null!;
+     
+    IReadOnlyDocumentStore<Event, string>? ReadonlyNullablePropRODS {get;} = null!;
+    IReadOnlyDocumentStore<Event, string>? MutableNullablePropRODS {get;set;} = null;
+    static IReadOnlyDocumentStore<Event, string>? StaticReadonlyNullablePropRODS {get;set;} = null;
+
+    // these are allowed (not Event)
+    IDocumentStore<Project, string> ReadonlyPropNotEvent {get;} = null!;
+    IDocumentStore<Project, string> MutablePropNotEvent {get;set;} = null!;
+    static IDocumentStore<Project, string> StaticReadonlyPropNotEvent {get;set;} = null!;
+     
+    IDocumentStore<Project, string>? ReadonlyNullablePropNotEvent {get;} = null!;
+    IDocumentStore<Project, string>? MutableNullablePropNotEvent {get;set;} = null;
+    static IDocumentStore<Project, string>? StaticReadonlyNullablePropNotEvent {get;set;} = null;
+  }
+}");
+            await Verify.VerifyAnalyzerAsync(source,
+                new DiagnosticResult(Descriptors.DontUseIDocumentStoreOfEvent).WithLocation(0),
+                new DiagnosticResult(Descriptors.DontUseIDocumentStoreOfEvent).WithLocation(1),
+                new DiagnosticResult(Descriptors.DontUseIDocumentStoreOfEvent).WithLocation(2),
+                new DiagnosticResult(Descriptors.DontUseIDocumentStoreOfEvent).WithLocation(3),
+                new DiagnosticResult(Descriptors.DontUseIDocumentStoreOfEvent).WithLocation(4),
+                new DiagnosticResult(Descriptors.DontUseIDocumentStoreOfEvent).WithLocation(5));
+        }
+        
+        [Test]
+        public async Task DiagnosticOnConstructorParam()
+        {
+            var source = WithOctopusTypes(@"
+namespace Octopus.Core {
+  public class SomeClass {
+    public SomeClass(
+      {|#0:IDocumentStore<Event, string>|} eventStore,
+      {|#1:IDocumentStore<Event, string>|}? nullableEventStore,
+      IDocumentStore<Project, string> projectStore,
+      IReadOnlyDocumentStore<Event, string> eventStoreRo,
+      IReadOnlyDocumentStore<Event, string>? nullableEventStoreRo)
+    { }
+  }
+}");
+            await Verify.VerifyAnalyzerAsync(source,
+                new DiagnosticResult(Descriptors.DontUseIDocumentStoreOfEvent).WithLocation(0),
+                new DiagnosticResult(Descriptors.DontUseIDocumentStoreOfEvent).WithLocation(1));
+        }
+
+        static readonly string LocalUsings = "using Octopus.Data.Model;using Octopus.Core.Persistence;using Octopus.Core.Model.Events;using Octopus.Core.Model.Projects;";
+
+        static readonly string LocalDeclarations = @"
+namespace Octopus.Data.Model {
+    public interface IId : IId<string> { }
+
+    public interface IId<out TId> {
+        TId Id { get; }
+    }
+}
+namespace Octopus.Core.Persistence {
+  public interface IReadOnlyDocumentStore<TDocument, in TKey> where TDocument : class, IId<TKey> { }
+  public interface IDocumentStore<TDocument, in TKey> : IReadOnlyDocumentStore<TDocument, TKey> where TDocument : class, IId<TKey> { }
+}
+namespace Octopus.Core.Model.Events {
+  public class Event : IId {
+    public string Id {get;} = """"; 
+  }
+}
+namespace Octopus.Core.Model.Projects {
+  public class Project : IId {
+    public string Id {get;} = """"; 
+  }
+}";
+
+        static string WithOctopusTypes(string source) => $"{Common.Usings}{LocalUsings}{source}{Common.MessageTypeDeclarations}{LocalDeclarations}";
+    }
+}


### PR DESCRIPTION
Adds a new analyzer that detects `IDocumentStore<Event, string>` and flags an error against it.

Detects in Field, Property and Constructor parameters, but not in other places in order to reduce the complexity.

It's very fast (28ms across `msbuild Octopus.Server.csproj /t:Rebuild /binaryLogger /p:ReportAnalyzer=true`) but as a tradeoff it won't catch things like `var store = lifetimeScope.Resolve<IDocumentStore<Event, string>>()`.

![image](https://user-images.githubusercontent.com/6362/210527030-0ef7a3dc-88d9-405c-a80a-c8cbe92e1b16.png)
