### PR TITLE
Remove https://pkgs.dev.azure.com/dnceng from nuget.config as it is not needed

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Build Schema",
   "$ref": "#/definitions/build",
+  "title": "Build Schema",
   "definitions": {
     "build": {
       "type": "object",
@@ -25,6 +25,7 @@
             "AppVeyor",
             "AzurePipelines",
             "Bamboo",
+            "Bitbucket",
             "Bitrise",
             "GitHubActions",
             "GitLab",

--- a/NuGet.config
+++ b/NuGet.config
@@ -4,7 +4,6 @@
     <clear />
     <add key="Feedz.io" value="https://f.feedz.io/octopus-deploy/dependencies/nuget/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />


### PR DESCRIPTION
# Background

To improve security, we are auditing our use of NuGet packages and package sources.

The NuGet config in this repo had 

```
<add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
```

# Analysis

There does not seem to be any reason for this; there are no dotnet-tools configured or listed anywhere in the repository. I removed the entry, ran the nuke build script (which updated the `build.schema.json` file), and everything was fine.

# Results

Removes the package source